### PR TITLE
ci: npm cache and remove playwright action

### DIFF
--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -12,12 +12,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Set Node env
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Run build

--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -9,12 +9,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Set Node env
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Run build

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,12 +16,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'npm'
+      - name: Install Playwright dependencies
+        run: npx playwright install-deps
       - name: Install dependencies
         run: npm ci
       - name: Run linter check 
         run: npm run lint
-      - name: Set testing environment
-        uses: microsoft/playwright-github-action@v1
       - name: Run tests
         run: npm run test
       - name: Analyze with SonarCloud         


### PR DESCRIPTION
While I was working on implementing sonarqube, I noticed that `setup-node` action has [caching capability](https://github.com/actions/setup-node#caching-global-packages-data). Since we already have #124 I just wanted to try this simple change.

Also I noticed playwright-action [encourages to use playwright-cli](https://github.com/microsoft/playwright-github-action#%EF%B8%8F-you-dont-need-this-github-action-%EF%B8%8F) instead of their action. I followed their suggestion here too.