### PR TITLE
test: bl-icon is mocked for tests other than its own test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.18.0",
         "@web/dev-server-esbuild": "0.2.16",
-        "@web/dev-server-import-maps": "^0.0.6",
         "@web/dev-server-rollup": "^0.3.17",
         "@web/test-runner": "^0.13.15",
         "@web/test-runner-playwright": "^0.8.6",
@@ -2546,11 +2545,6 @@
       "version": "1.2.1",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@import-maps/resolve": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -6285,22 +6279,6 @@
       "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
-      }
-    },
-    "node_modules/@web/dev-server-import-maps": {
-      "version": "0.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@import-maps/resolve": "^1.0.1",
-        "@types/parse5": "^6.0.1",
-        "@web/dev-server-core": "^0.3.3",
-        "@web/parse5-utils": "^1.3.0",
-        "parse5": "^6.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@web/dev-server-rollup": {
@@ -26033,10 +26011,6 @@
       "version": "1.2.1",
       "dev": true
     },
-    "@import-maps/resolve": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -28747,18 +28721,6 @@
           "version": "0.12.29",
           "dev": true
         }
-      }
-    },
-    "@web/dev-server-import-maps": {
-      "version": "0.0.6",
-      "dev": true,
-      "requires": {
-        "@import-maps/resolve": "^1.0.1",
-        "@types/parse5": "^6.0.1",
-        "@web/dev-server-core": "^0.3.3",
-        "@web/parse5-utils": "^1.3.0",
-        "parse5": "^6.0.1",
-        "picomatch": "^2.2.2"
       }
     },
     "@web/dev-server-rollup": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
     "@web/dev-server-esbuild": "0.2.16",
-    "@web/dev-server-import-maps": "^0.0.6",
     "@web/dev-server-rollup": "^0.3.17",
     "@web/test-runner": "^0.13.15",
     "@web/test-runner-playwright": "^0.8.6",

--- a/src/components/badge/bl-badge.test.ts
+++ b/src/components/badge/bl-badge.test.ts
@@ -3,21 +3,6 @@ import BlBadge from './bl-badge';
 import type typeOfBlBadge from './bl-badge';
 
 describe('bl-badge', () => {
-  const oldFetch = window.fetch;
-
-  before(() => {
-    window.fetch = async (url: RequestInfo) => {
-      if (/info\.svg$/.test(url.toString())) {
-        return new Response('<svg></svg>');
-      }
-      return new Response('', { status: 404 });
-    };
-  });
-
-  after(() => {
-    window.fetch = oldFetch;
-  });
-
   it('should be defined badge instance', () => {
     //when
     const el = document.createElement('bl-badge');

--- a/src/components/button/bl-button.test.ts
+++ b/src/components/button/bl-button.test.ts
@@ -7,21 +7,6 @@ import type typeOfBlButton from './bl-button';
 const variants = ['primary', 'secondary', 'tertiary', 'success', 'danger'];
 
 describe('bl-button', () => {
-  const oldFetch = window.fetch;
-
-  before(() => {
-    window.fetch = async (url: RequestInfo) => {
-      if (/info\.svg$/.test(url.toString())) {
-        return new Response('<svg></svg>');
-      }
-      return new Response('', { status: 404 });
-    };
-  });
-
-  after(() => {
-    window.fetch = oldFetch;
-  });
-
   it('is defined', () => {
     const el = document.createElement('bl-button');
     assert.instanceOf(el, BlButton);

--- a/src/components/input/bl-input.test.ts
+++ b/src/components/input/bl-input.test.ts
@@ -2,21 +2,6 @@ import { assert, expect, fixture, oneEvent, html } from '@open-wc/testing';
 import BlInput from './bl-input';
 
 describe('bl-input', () => {
-  const oldFetch = window.fetch;
-
-  before(() => {
-    window.fetch = async (url: RequestInfo | URL) => {
-      if (/.svg$/.test(url.toString())) {
-        return new Response('<svg></svg>');
-      }
-      return new Response('', { status: 404 });
-    };
-  });
-
-  after(() => {
-    window.fetch = oldFetch;
-  });
-
   it('is defined', () => {
     const el = document.createElement('bl-input');
     assert.instanceOf(el, BlInput);

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -21,9 +21,9 @@ if (args.debug) {
       launchOptions: {
         args: ['--no-sandbox'],
         devtools: true,
-        headless: !!args.headless
-      }
-    })
+        headless: !!args.headless,
+      },
+    }),
   ];
 }
 
@@ -51,6 +51,29 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
   browsers,
 
   plugins: [
+    {
+      name: 'mock-icon-component',
+      async transformImport({ source }) {
+        if (source.endsWith('bl-icon.ts')) {
+          return `${source}?_=${Date.now()}`;
+        }
+      },
+      serve(context) {
+        if (context.headers.referer) {
+          const ref = new URL(context.headers.referer);
+
+          if (
+            context.path === '/src/components/icon/bl-icon.ts' &&
+            ref.pathname !== '/' &&
+            // Use actual component in bl-icon test
+            !ref.pathname.includes('bl-icon.test.ts')
+          ) {
+            return `export default customElements.define('bl-icon', class extends HTMLElement {});`;
+          }
+        }
+      },
+    },
+    
     litCss({
       include: ['src/components/**/*.css'],
     }),


### PR DESCRIPTION
No more need to require mocking fetch method because of using `bl-icon` component
inside others.

Closes #147 