### PR TITLE
fix(tooltip): change max-width for tooltip

### DIFF
--- a/src/components/tooltip/bl-tooltip.css
+++ b/src/components/tooltip/bl-tooltip.css
@@ -28,7 +28,7 @@
   top: var(--bl-tooltip-top);
   visibility: var(--bl-tooltip-visibility);
   z-index: 999;
-  max-width: 312px;
+  max-width: 424px;
 }
 
 .arrow {


### PR DESCRIPTION
As a result of our conversation with @buseselvi, due to the content doesn't fit in the tooltip, the max-width has been changed.