### PR TITLE
fix(button)!: button attributes refactored

### DIFF
--- a/src/components/button/bl-button.css
+++ b/src/components/button/bl-button.css
@@ -76,28 +76,28 @@
   --bl-button-margin-icon: 0;
 }
 
-:host([variant=secondary]) {
+:host([variant='secondary']) {
   --bl-button-main-color: var(--bl-color-secondary);
   --bl-button-main-hover-color: var(--bl-color-secondary-hover);
 }
 
-:host([variant=success]) {
+:host([variant='success']) {
   --bl-button-main-color: var(--bl-color-success);
   --bl-button-main-hover-color: var(--bl-color-success-hover);
 }
 
-:host([variant=danger]) {
+:host([variant='danger']) {
   --bl-button-main-color: var(--bl-color-danger);
   --bl-button-main-hover-color: var(--bl-color-danger-hover);
 }
 
-:host([fill=text]) {
+:host([fill='text']) {
   --bl-button-content-color: var(--bl-button-main-color);
   --bl-button-border-color: transparent;
   --bl-button-bg-color: transparent;
 }
 
-:host([fill=text]) .button {
+:host([fill='text']) .button {
   text-decoration: underline;
 }
 
@@ -115,15 +115,15 @@
   text-decoration: none;
 }
 
-:host([fill=outline]) {
+:host([fill='outline']) {
   --bl-button-bg-color: transparent;
 }
 
-:host([fill=outline]:not(:hover):not([disabled])) {
+:host([fill='outline']:not(:hover):not([disabled])) {
   --bl-button-content-color: var(--bl-button-main-color);
 }
 
-:host([fill=text]:not([disabled])) .button:hover {
+:host([fill='text']:not([disabled])) .button:hover {
   --bl-button-content-color: var(--bl-button-main-hover-color);
   --bl-button-border-color: transparent;
   --bl-button-bg-color: transparent;

--- a/src/components/button/bl-button.css
+++ b/src/components/button/bl-button.css
@@ -76,28 +76,28 @@
   --bl-button-margin-icon: 0;
 }
 
-:host([secondary]) {
+:host([variant=secondary]) {
   --bl-button-main-color: var(--bl-color-secondary);
   --bl-button-main-hover-color: var(--bl-color-secondary-hover);
 }
 
-:host([success]) {
+:host([variant=success]) {
   --bl-button-main-color: var(--bl-color-success);
   --bl-button-main-hover-color: var(--bl-color-success-hover);
 }
 
-:host([danger]) {
+:host([variant=danger]) {
   --bl-button-main-color: var(--bl-color-danger);
   --bl-button-main-hover-color: var(--bl-color-danger-hover);
 }
 
-:host([text]) {
+:host([fill=text]) {
   --bl-button-content-color: var(--bl-button-main-color);
   --bl-button-border-color: transparent;
   --bl-button-bg-color: transparent;
 }
 
-:host([text]) .button {
+:host([fill=text]) .button {
   text-decoration: underline;
 }
 
@@ -115,15 +115,15 @@
   text-decoration: none;
 }
 
-:host([outline]) {
+:host([fill=outline]) {
   --bl-button-bg-color: transparent;
 }
 
-:host([outline]:not(:hover):not([disabled])) {
+:host([fill=outline]:not(:hover):not([disabled])) {
   --bl-button-content-color: var(--bl-button-main-color);
 }
 
-:host([text]:not([disabled])) .button:hover {
+:host([fill=text]:not([disabled])) .button:hover {
   --bl-button-content-color: var(--bl-button-main-hover-color);
   --bl-button-border-color: transparent;
   --bl-button-bg-color: transparent;

--- a/src/components/button/bl-button.css
+++ b/src/components/button/bl-button.css
@@ -105,26 +105,26 @@
   text-decoration: none;
 }
 
-:host([fill='text']) {
+:host([kind='text']) {
   --bl-button-content-color: var(--bl-button-main-color);
   --bl-button-border-color: transparent;
   --bl-button-bg-color: transparent;
 }
 
-:host([fill='text']) .button {
+:host([kind='text']) .button {
   text-decoration: underline;
 }
 
-:host([fill='outline']) {
+:host([kind='outline']) {
   --bl-button-bg-color: transparent;
   --bl-button-content-color: var(--bl-button-main-color);
 }
 
-:host([fill='outline']:hover:not([disabled])) {
+:host([kind='outline']:hover:not([disabled])) {
   --bl-button-content-color: var(--bl-color-primary-background);
   --bl-button-bg-color: var(--bl-button-main-hover-color);
 }
 
-:host([fill='text']:hover:not([disabled])) {
+:host([kind='text']:hover:not([disabled])) {
   --bl-button-content-color: var(--bl-button-main-hover-color);
 }

--- a/src/components/button/bl-button.stories.mdx
+++ b/src/components/button/bl-button.stories.mdx
@@ -18,7 +18,7 @@ import { Meta, Canvas, ArgsTable, Story, Preview, Source } from '@storybook/addo
       default: 'primary',
       control: { type: 'select' }
     },
-    fill: {
+    kind: {
       options: ['contained', 'outline', 'text'],
       default: 'contained',
       control: { type: 'select' }
@@ -50,7 +50,7 @@ import { Meta, Canvas, ArgsTable, Story, Preview, Source } from '@storybook/addo
 
 export const SingleButtonTemplate = (args) => html`<bl-button
     variant=${ifDefined(args.variant)}
-    fill=${ifDefined(args.fill)}
+    kind=${ifDefined(args.kind)}
     href=${ifDefined(args.href)}
     target=${ifDefined(args.target)}
     size=${ifDefined(args.size)}
@@ -68,8 +68,8 @@ ${SingleButtonTemplate({variant: 'danger', content: 'Danger Button', ...args})}`
 
 export const ButtonTypesTemplate = (args) => html`
 ${SingleButtonTemplate({...args})}
-${SingleButtonTemplate({fill: 'outline', ...args})}
-${SingleButtonTemplate({fill: 'text', ...args})}`;
+${SingleButtonTemplate({kind: 'outline', ...args})}
+${SingleButtonTemplate({kind: 'text', ...args})}`;
 
 export const SizesTemplate = (args) => html`
 ${SingleButtonTemplate({size: 'large', ...args})}
@@ -78,8 +78,8 @@ ${SingleButtonTemplate({size: 'small', ...args})}`;
 
 export const VariousStylesTemplate = (args) => html`
 ${SingleButtonTemplate({...args})}
-${SingleButtonTemplate({fill: 'outline', ...args})}
-${SingleButtonTemplate({fill: 'text', ...args})}`;
+${SingleButtonTemplate({kind: 'outline', ...args})}
+${SingleButtonTemplate({kind: 'text', ...args})}`;
 
 # Button
 
@@ -128,7 +128,7 @@ Outlined Buttons represent the important actions in the app. But not the primary
 They work with all the variants. You simply add `outline` attribute.
 
 <Canvas>
-  <Story name="Outline Buttons" args={{ fill: 'outline' }}>
+  <Story name="Outline Buttons" args={{ kind: 'outline' }}>
     {Template.bind({})}
   </Story>
 </Canvas>
@@ -136,7 +136,7 @@ They work with all the variants. You simply add `outline` attribute.
 ### Text Buttons
 TBD
 <Canvas>
-  <Story name="Text Buttons" args={{ fill: 'text' }}>
+  <Story name="Text Buttons" args={{ kind: 'text' }}>
     {Template.bind({})}
   </Story>
 </Canvas>
@@ -155,7 +155,7 @@ To be able to use icon with button, you should give the name of icon to `icon` a
 </Canvas>
 
 <Canvas>
-  <Story name="Text Buttons With Icon" args={{ fill: 'text', href: "https://trendyol.com", content: 'Save', icon: 'info' }}>
+  <Story name="Text Buttons With Icon" args={{ kind: 'text', href: "https://trendyol.com", content: 'Save', icon: 'info' }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/button/bl-button.stories.mdx
+++ b/src/components/button/bl-button.stories.mdx
@@ -51,31 +51,27 @@ import { Meta, Canvas, ArgsTable, Story, Preview, Source } from '@storybook/addo
 />
 
 export const SingleButtonTemplate = (args) => html`<bl-button
-    ?primary=${args.primary}
-    ?secondary=${args.secondary}
-    ?success=${args.success}
-    ?danger=${args.danger}
-    ?outline=${args.outline}
-    ?disabled=${args.disabled}
-    ?text=${args.text}
+    variant=${ifDefined(args.variant)}
+    fill=${ifDefined(args.fill)}
     href=${ifDefined(args.href)}
     target=${ifDefined(args.target)}
     size=${ifDefined(args.size)}
     icon="${ifDefined(args.icon)}"
     label="${ifDefined(args.label)}"
+    ?disabled=${args.disabled}
     style=${ifDefined(args.styles ? styleMap(args.styles) : undefined)}
       >${unsafeHTML(args.content)}</bl-button>`
 
 export const Template = (args) => html`
-${SingleButtonTemplate({primary: true, content: 'Primary Button', ...args})}
-${SingleButtonTemplate({secondary: true, content: 'Secondary Button', ...args})}
-${SingleButtonTemplate({success: true, content: 'Success Button', ...args})}
-${SingleButtonTemplate({danger: true, content: 'Danger Button', ...args})}`;
+${SingleButtonTemplate({content: 'Primary Button', ...args})}
+${SingleButtonTemplate({variant: 'secondary', content: 'Secondary Button', ...args})}
+${SingleButtonTemplate({variant: 'success', content: 'Success Button', ...args})}
+${SingleButtonTemplate({variant: 'danger', content: 'Danger Button', ...args})}`;
 
 export const ButtonTypesTemplate = (args) => html`
 ${SingleButtonTemplate({...args})}
-${SingleButtonTemplate({outline: true, ...args})}
-${SingleButtonTemplate({text: true, ...args})}`;
+${SingleButtonTemplate({fill: 'outline', ...args})}
+${SingleButtonTemplate({fill: 'text', ...args})}`;
 
 export const SizesTemplate = (args) => html`
 ${SingleButtonTemplate({size: 'large', ...args})}
@@ -84,8 +80,8 @@ ${SingleButtonTemplate({size: 'small', ...args})}`;
 
 export const VariousStylesTemplate = (args) => html`
 ${SingleButtonTemplate({...args})}
-${SingleButtonTemplate({outline: true, ...args})}
-${SingleButtonTemplate({text: true, ...args})}`;
+${SingleButtonTemplate({fill: 'outline', ...args})}
+${SingleButtonTemplate({fill: 'text', ...args})}`;
 
 # Button
 
@@ -125,7 +121,7 @@ Contained buttons ared used for main actions of the screens. Like a submit butto
 Outlined Buttons represent the important actions in the app. But not the primary ones.
 They work with all the variants. You simply add `outline` attribute.
 <Canvas>
-  <Story name="Outline Buttons" args={{ outline: true }}>
+  <Story name="Outline Buttons" args={{ fill: 'outline' }}>
     {Template.bind({})}
   </Story>
 </Canvas>
@@ -133,7 +129,7 @@ They work with all the variants. You simply add `outline` attribute.
 ### Text Buttons
 TBD
 <Canvas>
-  <Story name="Text Buttons" args={{ text: true }}>
+  <Story name="Text Buttons" args={{ fill: 'text' }}>
     {Template.bind({})}
   </Story>
 </Canvas>
@@ -151,7 +147,7 @@ To be able to use icon with button, you should give the name of icon to `icon` a
 </Canvas>
 
 <Canvas>
-  <Story name="Text Buttons With Icon" args={{ text: true, href: "https://trendyol.com", content: 'Save', icon: 'info' }}>
+  <Story name="Text Buttons With Icon" args={{ fill: 'text', href: "https://trendyol.com", content: 'Save', icon: 'info' }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/components/button/bl-button.stories.mdx
+++ b/src/components/button/bl-button.stories.mdx
@@ -13,17 +13,15 @@ import { Meta, Canvas, ArgsTable, Story, Preview, Source } from '@storybook/addo
         type: 'text'
       }
     },
-    primary: {
-      control: 'boolean'
+    variant: {
+      options: ['primary', 'secondary', 'success', 'danger'],
+      default: 'primary',
+      control: { type: 'select' }
     },
-    secondary: {
-      control: 'boolean'
-    },
-    success: {
-      control: 'boolean'
-    },
-    danger: {
-      control: 'boolean'
+    fill: {
+      options: ['contained', 'outline', 'text'],
+      default: 'contained',
+      control: { type: 'select' }
     },
     disabled: {
       control: 'boolean'
@@ -88,13 +86,16 @@ ${SingleButtonTemplate({fill: 'text', ...args})}`;
 Buttons allow users to take actions, and make choices with a single tap.
 
 ### Usage
+
 * A button should contain at least one text, icon or both (text + icon).
 * The first letter of the word on the buttons is capitalized and the rest is lowercase.
 * The icons on the buttons are left aligned.
 * Button texts are limited to one line.
 
 ## Button Variants
+
 We have 4 variants for each button: **Primary**, **Secondary**, **Success** and **Danger**.
+
 <Canvas>
   <Story name="Variants">
     {Template.bind({})}
@@ -102,7 +103,9 @@ We have 4 variants for each button: **Primary**, **Secondary**, **Success** and 
 </Canvas>
 
 ## Button Types
+
 We have 3 types of buttons: **Contained** (Default), **Outline** and **Text**.
+
 <Canvas>
   <Story name="Types" args={{ content: 'Primary Button' }}>
     {ButtonTypesTemplate.bind({})}
@@ -110,7 +113,9 @@ We have 3 types of buttons: **Contained** (Default), **Outline** and **Text**.
 </Canvas>
 
 ### Contained Buttons
+
 Contained buttons ared used for main actions of the screens. Like a submit button in a form or main button of a dialog.
+
 <Canvas>
   <Story name="Contained Buttons">
     {Template.bind({})}
@@ -118,8 +123,10 @@ Contained buttons ared used for main actions of the screens. Like a submit butto
 </Canvas>
 
 ### Outline Buttons
+
 Outlined Buttons represent the important actions in the app. But not the primary ones.
 They work with all the variants. You simply add `outline` attribute.
+
 <Canvas>
   <Story name="Outline Buttons" args={{ fill: 'outline' }}>
     {Template.bind({})}
@@ -135,8 +142,9 @@ TBD
 </Canvas>
 
 ## Icon Buttons
-To boost `UX`, you might want to add icons to your button. Because human brain recognize `icons` more easily than `text text`.
-Our icons are defined to be `left` of the default slot.
+
+To boost UX, you might want to add icons to your button. Because human brain recognize icons more easily than text.
+Our icons are defined to be left of the default slot.
 
 To be able to use icon with button, you should give the name of icon to `icon` attribute.
 
@@ -190,7 +198,9 @@ If button has a limited width and a long text that can not fit in a single line,
 </Canvas>
 
 ## Disabled buttons
+
 We have 2 types of disabled buttons: **Contained** and **Text**. Disable version of Contained and Outline buttons is the same.
+
 <Canvas columns={1}>
   <Story name="Disabled buttons" args={{ disabled: true, content: 'Passive Button' }}>
     {SizesTemplate.bind({})}

--- a/src/components/button/bl-button.test.ts
+++ b/src/components/button/bl-button.test.ts
@@ -1,6 +1,5 @@
 import { assert, expect, fixture, elementUpdated, oneEvent, html } from '@open-wc/testing';
 import BlButton from './bl-button';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import type typeOfBlButton from './bl-button';
 
@@ -34,8 +33,7 @@ describe('bl-button', () => {
   xdescribe('Accessibility tests', () => {
     variants.forEach(variant => {
       it(`should be accessible when attribute is "${variant}"`, async () => {
-        const htmlStr = `<bl-button ${variant}>Button</bl-button>`;
-        const el = await fixture<typeOfBlButton>(html`${unsafeHTML(htmlStr)}`);
+        const el = await fixture<typeOfBlButton>(`<bl-button variant=${variant}>Button</bl-button>`);
         await expect(el).to.be.accessible();
       });
     });

--- a/src/components/button/bl-button.test.ts
+++ b/src/components/button/bl-button.test.ts
@@ -33,7 +33,9 @@ describe('bl-button', () => {
   xdescribe('Accessibility tests', () => {
     variants.forEach(variant => {
       it(`should be accessible when attribute is "${variant}"`, async () => {
-        const el = await fixture<typeOfBlButton>(`<bl-button variant=${variant}>Button</bl-button>`);
+        const el = await fixture<typeOfBlButton>(
+          `<bl-button variant=${variant}>Button</bl-button>`
+        );
         await expect(el).to.be.accessible();
       });
     });

--- a/src/components/button/bl-button.ts
+++ b/src/components/button/bl-button.ts
@@ -6,25 +6,14 @@ import { event, EventDispatcher } from '../../utilities/event';
 import style from './bl-button.css';
 import '../icon/bl-icon';
 
+export type ButtonVariant = 'primary' | 'secondary' | 'success' | 'danger';
+export type ButtonFill = 'contained' | 'outline' | 'text';
 export type ButtonSize = 'small' | 'medium' | 'large';
 export type TargetType = '_blank' | '_parent' | '_self' | '_top';
 
 /**
  * @tag bl-button
  * @summary Baklava Button component
- *
- * @property {boolean} primary - Sets variant to primary
- * @property {boolean} secondary - Sets variant to secondary
- * @property {boolean} success - Sets variant to success
- * @property {boolean} danger - Sets variant to danger
- * @property {boolean} outline - Sets button version to outline
- * @property {boolean} text - Sets the button version to text
- * @property {boolean} disabled - Disables the button
- * @property {string} size - Sets the button size
- * @property {string} icon - Sets the name of the icon
- * @property {string} href - Sets link of the button
- * @property {string} target - Sets button target (should be defined with href)
- * @property {string} label - Sets the accessibility text for the button. Use it with icon-only buttons.
  *
  * @cssproperty --bl-button-display - Sets the display property of button. Default value is 'inline-block'.
  *
@@ -35,39 +24,51 @@ export default class BlButton extends LitElement {
     return [style];
   }
 
-  @property({ type: Boolean, reflect: true })
-  primary = false;
+  /**
+   * Sets the button variant
+   */
+  @property({ type: String, reflect: true })
+  variant: ButtonVariant = 'primary';
 
-  @property({ type: Boolean, reflect: true })
-  secondary = false;
+  /**
+   * Sets the button fill
+   */
+  @property({ type: String, reflect: true })
+  fill: ButtonFill = 'contained';
 
-  @property({ type: Boolean, reflect: true })
-  success = false;
-
-  @property({ type: Boolean, reflect: true })
-  danger = false;
-
-  @property({ type: Boolean, reflect: true })
-  outline = false;
-
-  @property({ type: Boolean, reflect: true })
-  text = false;
-
+  /**
+   * Sets the button size
+   */
   @property({ type: String, reflect: true })
   size: ButtonSize = 'medium';
 
+  /**
+   * Sets the button label. Used for accessibility.
+   */
   @property({ type: String })
   label: string;
 
+  /**
+   * Sets button as disabled
+   */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
+  /**
+   * Set link url. If set, button will be rendered as anchor tag.
+   */
   @property({ type: String })
   href?: string;
 
+  /**
+   * Sets the icon name. Shows icon with bl-icon component
+   */
   @property({ type: String })
   icon?: string;
 
+  /**
+   * Sets the anchor target. Used when `href` is set.
+   */
   @property({ type: String })
   target?: TargetType = '_self';
 

--- a/src/components/button/bl-button.ts
+++ b/src/components/button/bl-button.ts
@@ -7,7 +7,7 @@ import style from './bl-button.css';
 import '../icon/bl-icon';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'success' | 'danger';
-export type ButtonFill = 'contained' | 'outline' | 'text';
+export type ButtonKind = 'contained' | 'outline' | 'text';
 export type ButtonSize = 'small' | 'medium' | 'large';
 export type TargetType = '_blank' | '_parent' | '_self' | '_top';
 
@@ -31,10 +31,10 @@ export default class BlButton extends LitElement {
   variant: ButtonVariant = 'primary';
 
   /**
-   * Sets the button fill
+   * Sets the button kind
    */
   @property({ type: String, reflect: true })
-  fill: ButtonFill = 'contained';
+  kind: ButtonKind = 'contained';
 
   /**
    * Sets the button size

--- a/src/components/tab-group/tab/bl-tab.ts
+++ b/src/components/tab-group/tab/bl-tab.ts
@@ -101,9 +101,9 @@ export default class BlTab extends LitElement {
             <bl-button
               slot="tooltip-trigger"
               icon="info"
-              text
+              variant="secondary"
+              kind="text"
               label="${this.helpText}"
-              secondary
             ></bl-button>
             ${this.helpText}
           </bl-tooltip>

--- a/src/components/tooltip/bl-tooltip.stories.mdx
+++ b/src/components/tooltip/bl-tooltip.stories.mdx
@@ -26,7 +26,7 @@ export const tooltipOpener = async ({ canvasElement }) => {
 
 export const IconTriggerTemplate = (args) => html`
 <bl-tooltip placement="${ifDefined(args.placement)}" style='--bl-tooltip-position:fixed'>
-  <bl-button slot="tooltip-trigger" icon="settings" fill="text" label="Settings" variant="secondary"></bl-button>
+  <bl-button slot="tooltip-trigger" icon="settings" kind="text" label="Settings" variant="secondary"></bl-button>
   Settings
 </bl-tooltip>`
 

--- a/src/components/tooltip/bl-tooltip.stories.mdx
+++ b/src/components/tooltip/bl-tooltip.stories.mdx
@@ -26,7 +26,7 @@ export const tooltipOpener = async ({ canvasElement }) => {
 
 export const IconTriggerTemplate = (args) => html`
 <bl-tooltip placement="${ifDefined(args.placement)}" style='--bl-tooltip-position:fixed'>
-  <bl-button slot="tooltip-trigger" icon="settings" fill="text" label="Settings" secondary></bl-button>
+  <bl-button slot="tooltip-trigger" icon="settings" fill="text" label="Settings" variant="secondary"></bl-button>
   Settings
 </bl-tooltip>`
 

--- a/src/components/tooltip/bl-tooltip.stories.mdx
+++ b/src/components/tooltip/bl-tooltip.stories.mdx
@@ -26,7 +26,7 @@ export const tooltipOpener = async ({ canvasElement }) => {
 
 export const IconTriggerTemplate = (args) => html`
 <bl-tooltip placement="${ifDefined(args.placement)}" style='--bl-tooltip-position:fixed'>
-  <bl-button slot="tooltip-trigger" icon="settings" text label="Settings" secondary></bl-button>
+  <bl-button slot="tooltip-trigger" icon="settings" fill="text" label="Settings" secondary></bl-button>
   Settings
 </bl-tooltip>`
 
@@ -39,7 +39,7 @@ export const ButtonTriggerTemplate = (args) => html`
 
 export const PlacementTemplate = (args) => html`
 <bl-tooltip placement="${ifDefined(args.placement)}" style="--bl-tooltip-position:fixed">
-  <bl-button slot="tooltip-trigger" small>${args.placement}</bl-button>
+  <bl-button slot="tooltip-trigger">${args.placement}</bl-button>
   You can use this section to cancel your order.
 </bl-tooltip>`
 


### PR DESCRIPTION
**This is a BREAKING CHANGE**

Currently we use boolean attributes for button variants (`primary`, `secondary`, `success`, `danger`) and types (`contained`, `outline`, `text`). In the beginning we thought this is easier to write but currently I see that this is conflicting with the approach how we use boolean attributes in other components and how we really should use them. Boolean attributes should not rely on other attributes. But now we are technically allowed to write `<bl-button primary secondary>` and in this case result relies on our CSS specifity. And this type of writing does give the feeling that it's possible.

I think we need to fix this as soon as possible to not make confusion for new comers.

This PR converts boolean variants to a more standart `variant` attribute with a default `primary` value again. I picked `fill` attribute value for button types (we use type in storybook) because probably `type` attribute will be needed in near future for using a button as a submitter of a form. Since HTML `button` has `type` I thought we should not use `type` for setting button as `outline` or `text`. Opinions are very welcome.