### PR TITLE
docs: add Styling Components section to react doc

### DIFF
--- a/docs/using-baklava-in-react.stories.mdx
+++ b/docs/using-baklava-in-react.stories.mdx
@@ -125,8 +125,8 @@ import { BlButton } from "@trendyol/baklava/dist/baklava-react";
 
 function MyComponent() {
   const buttonStyle = {
-    "--bl-button-main-color": "rebeccapurple",
-    "--bl-button-main-hover-color": "purple",
+    "--bl-color-primary": "purple",
+    "--bl-color-primary-hover": "rebeccapurple",
   }
 
   return (
@@ -145,11 +145,11 @@ import styled from "styled-components"
 
 const Wrapper = styled.div`
    .button-class {
-     --bl-button-main-color: red;
+     --bl-color-primary: purple;
    }
-
+   
    .tooltip-class {
-     --bl-tooltip-top: 100px !important;
+     --bl-color-primary-hover: rebeccapurple;
    }
 `;
 

--- a/docs/using-baklava-in-react.stories.mdx
+++ b/docs/using-baklava-in-react.stories.mdx
@@ -147,9 +147,9 @@ const Wrapper = styled.div`
    .button-class {
      --bl-color-primary: purple;
    }
-   
+
    .tooltip-class {
-     --bl-color-primary-hover: rebeccapurple;
+     --bl-tooltip-position: fixed;
    }
 `;
 

--- a/docs/using-baklava-in-react.stories.mdx
+++ b/docs/using-baklava-in-react.stories.mdx
@@ -114,3 +114,55 @@ function MyComponent() {
 
 export default MyComponent;
 ```
+
+## Styling Components
+You can customize components with css variables or general theme variables.
+
+#### Inline CSS
+
+```jsx
+import { BlButton } from "@trendyol/baklava/dist/baklava-react";
+
+function MyComponent() {
+  const buttonStyle = {
+    "--bl-button-main-color": "rebeccapurple",
+    "--bl-button-main-hover-color": "purple",
+  }
+
+  return (
+    <BlButton style={buttonStyle}>button</BlButton>
+  );
+}
+
+export default MyComponent;
+```
+
+#### Styled Components
+
+```jsx
+import { BlTooltip, BlButton } from "@trendyol/baklava/dist/baklava-react";
+import styled from "styled-components"
+
+const Wrapper = styled.div`
+   .button-class {
+     --bl-button-main-color: red;
+   }
+
+   .tooltip-class {
+     --bl-tooltip-top: 100px !important;
+   }
+`;
+
+function MyComponent() {
+  return (
+    <Wrapper>
+      <BlTooltip className="tooltip-class">
+        <BlButton className="button-class" slot="tooltip-trigger" icon="info" text label="Show Info" />
+        Some extra information.
+      </BlTooltip>
+    </Wrapper>
+  );
+}
+
+export default MyComponent;
+```


### PR DESCRIPTION
I think it would be useful for React users to see directly from the doc how to style components.