### PR TITLE
feat: minify css

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -39,6 +39,7 @@ const args = parseArgs(process.argv.slice(2), {
       external: ['react'],
       plugins: [
         litCssPlugin({
+          uglify: true,
           filter: /components\/.*\.css$/,
         }),
       ],


### PR DESCRIPTION
There is a builtin option in our css plugin named [uglifycss](https://www.npmjs.com/package/uglifycss). So, we can just add `uglify: true` option to minify our css. Output seems good and I didn't want to add another step/plugin to minify the css. I believe, this'll work for us.

Closes #175 
