### PR TITLE
Tooltip: Add max-content width

### DIFF
--- a/src/components/tooltip/bl-tooltip.css
+++ b/src/components/tooltip/bl-tooltip.css
@@ -22,6 +22,7 @@
   visibility: var(--visibility);
   z-index: 999;
   max-width: 424px;
+  width: max-content;
 }
 
 .arrow {


### PR DESCRIPTION
The tooltip shrink without off max-content width. You can see from [Stackblitz](https://stackblitz.com/edit/vitejs-vite-pdvgcp?file=src/App.css).

Steps to reproduce:
1. Create a fixed size div with `transform: translateY(1px);` style.
2. Add tooltip inside.

OLD:
![image](https://user-images.githubusercontent.com/10272532/191843437-43116870-1955-4bd4-a6ec-91dc13c7a8eb.png)

NEW:
![image](https://user-images.githubusercontent.com/10272532/191843488-2bbe90bb-c727-4175-b878-530061b9fa7f.png)
