### PR TITLE
fix(select): fix delay of arrow icon change on opening popup

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,7 +16,8 @@ module.exports = {
         'tooltip',
         'progress-indicator',
         'checkbox',
-        'alert'
+        'alert',
+        'select'
       ],
     ],
   },

--- a/src/components/select/bl-select.css
+++ b/src/components/select/bl-select.css
@@ -94,6 +94,18 @@
   font-size: var(--bl-font-size-m);
 }
 
+.dropdown-icon.open {
+  display: none;
+}
+
+.select-open .dropdown-icon.open {
+  display: inline-block;
+}
+
+.select-open .dropdown-icon.closed {
+  display: none;
+}
+
 .selected .dropdown-icon {
   --icon-color: var(--bl-color-secondary);
 }

--- a/src/components/select/bl-select.test.ts
+++ b/src/components/select/bl-select.test.ts
@@ -27,7 +27,8 @@ describe('bl-select', () => {
             variant="secondary"
           >
           </bl-button>
-          <bl-icon  class="dropdown-icon" name="arrow_down"></bl-icon>
+          <bl-icon class="dropdown-icon open" name="arrow_up"></bl-icon>
+          <bl-icon class="dropdown-icon closed" name="arrow_down"></bl-icon>
           </div>
         </div>
         <div class="popover">

--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -211,8 +211,13 @@ export default class BlSelect extends LitElement {
       <div class="actions">
         ${removeButton}
         <bl-icon
-          class="dropdown-icon"
-          name="${this._isPopoverOpen ? 'arrow_up' : 'arrow_down'}"
+          class="dropdown-icon open"
+          name="arrow_up"
+        ></bl-icon>
+
+        <bl-icon
+          class="dropdown-icon closed"
+          name="arrow_down"
         ></bl-icon>
       </div>
     </div>`;


### PR DESCRIPTION
When we open the popup of select, it changes the arrow icon from down to up. But since we are lazily loading icons, loading of the up icon can take some time regarding the network speed of the client. That timing causes taking randomly different screenshots on our Chromatic snapshots testing. As a result of this, our `next` branch can go to UI review status and block some PRs like #253.

I fixed this by including both icons in the dom by default and showing/hiding them with CSS. I think this is also better for even end users because with some lousy network connections, in current behavior, a user can see the delay of seeing icon change when they open select for the first time.