### PR TITLE
chore: deprecated extension removed

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
 		"EditorConfig.EditorConfig",
 		"dbaeumer.vscode-eslint",
 		"runem.lit-plugin",
-		"silvenon.mdx",
 		"streetsidesoftware.code-spell-checker",
 		"esbenp.prettier-vscode",
 		"stylelint.vscode-stylelint",


### PR DESCRIPTION
This extension has been deprecated in favor of the official MDX extension.

<img width="541" alt="image" src="https://user-images.githubusercontent.com/127687/195024470-f6a5e1d3-777d-4290-aaff-f58f0f5f738f.png">
