### PR TITLE
fix(pagination): totalItems change control added

### DIFF
--- a/src/components/pagination/bl-pagination.ts
+++ b/src/components/pagination/bl-pagination.ts
@@ -93,7 +93,7 @@ export default class BlPagination extends LitElement {
   @event('bl-change') private onChange: EventDispatcher<{ selectedPage: number; prevPage: number }>;
 
   updated(changedProperties: PropertyValues<this>) {
-    if (changedProperties.has('currentPage') || changedProperties.has('itemsPerPage')) {
+    if (changedProperties.has('currentPage') || changedProperties.has('itemsPerPage') || changedProperties.has('totalItems') ) {
       this._paginate();
       this.onChange({
         selectedPage: this.currentPage,


### PR DESCRIPTION
While using the pagination component in my project, I noticed that the pagination component does not refresh when the total count of items changes.

We get the total count of items from the backend and the pagination was not refreshing when the response came as we did not track this `totalItems` property. This pr fixes this problem.
