### PR TITLE
fix: pagination items per page options

### DIFF
--- a/src/components/pagination/bl-pagination.css
+++ b/src/components/pagination/bl-pagination.css
@@ -35,6 +35,8 @@
 
 .pagination-helpers {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   align-items: center;
   gap: var(--bl-size-m);
 }
@@ -61,4 +63,10 @@ bl-input {
 
 bl-select {
   width:128px;
+}
+
+@media only screen and (max-width: 768px) {
+  label {
+    display:none;
+  }
 }

--- a/src/components/pagination/bl-pagination.css
+++ b/src/components/pagination/bl-pagination.css
@@ -1,9 +1,9 @@
-:host {
-  width: max-content;
-}
-
 .pagination {
   display: flex;
+  flex-wrap:wrap;
+  justify-content: center;
+  max-width:max-content;
+  gap: var(--bl-size-s);
 }
 
 .pagination * {
@@ -36,7 +36,6 @@
 .pagination-helpers {
   display: flex;
   align-items: center;
-  margin-right: var(--bl-size-s);
   gap: var(--bl-size-m);
 }
 

--- a/src/components/pagination/bl-pagination.stories.mdx
+++ b/src/components/pagination/bl-pagination.stories.mdx
@@ -17,7 +17,7 @@ import { Meta, Canvas, ArgsTable, Story, Preview, Source } from '@storybook/addo
      itemsPerPage: {
        control: {
         type: 'number',
-        default:100
+        default:10
       }
     },
    hasJumper: {
@@ -44,10 +44,27 @@ import { Meta, Canvas, ArgsTable, Story, Preview, Source } from '@storybook/addo
         default:"Show"
       }
     },
-    optionText: {
+    selectOptions: {
       control: {
-        type: 'text',
-        default:"Items"
+        type: 'array',
+        default:
+          [
+            {
+              text: '100 Sonuç',
+              value: 100,
+            },
+            {
+              text: '250 Sonuç',
+              value: 250,
+            },
+            {
+              text: '500 Sonuç',
+              value: 500,
+            },
+            {
+              text: '1000 Sonuç',
+              value: 1000,
+            }]
       }
     },
   }}
@@ -62,7 +79,7 @@ export const PaginationTemplate = (args) => html`
       jumper-label=${ifDefined(args.jumperLabel)}
       has-select=${ifDefined(args.hasSelect)}
       select-label=${ifDefined(args.selectLabel)}
-      option-text=${ifDefined(args.optionText)}
+      select-options=${ifDefined(args.selectOptions)}
       >
       </bl-pagination>
   `
@@ -76,7 +93,7 @@ The Pagination component enables the user to select a specific page from a range
 Use a simple pagination for navigating to the next or previous page or a selected page.
 
 <Canvas>
-<Story name="Basic Usage" args={{currentPage:1,totalItems:1500,itemsPerPage:10}}>
+<Story name="Basic Usage" args={{currentPage:1,totalItems:1500}}>
     {PaginationTemplate.bind({})}
   </Story>
 </Canvas>
@@ -85,7 +102,7 @@ Use a simple pagination for navigating to the next or previous page or a selecte
 Use the jumper to directly go to a specific page.
 
 <Canvas>
-<Story name="Jumper" args={{currentPage:1,totalItems:1500,itemsPerPage:10,hasJumper:true}}>
+<Story name="Jumper" args={{currentPage:1,totalItems:1500,hasJumper:true}}>
     {PaginationTemplate.bind({})}
   </Story>
 </Canvas>
@@ -94,16 +111,42 @@ Use the jumper to directly go to a specific page.
 Use the select helper to change the number of items per page.
 
 <Canvas>
-<Story name="Select" args={{currentPage:1,totalItems:1500,itemsPerPage:100,hasSelect:true}}>
+<Story name="Select" args={{currentPage:1,totalItems:1500,hasSelect:true}}>
     {PaginationTemplate.bind({})}
   </Story>
 </Canvas>
 
 ## Customization
-The labels and the texts of the jumper and select element are fully customizable.
+The labels and the texts of the jumper and select element are fully customizable. The default select options can also be changed.
 
 <Canvas>
-<Story name="Customization"  args={{currentPage:1,totalItems:1500,itemsPerPage:250,hasJumper:true,jumperLabel:"Sayfaya Git",hasSelect:true,selectLabel:"Sayfa Başına",optionText:"Sonuç"}}>
+<Story name="Customization"  args={{
+  currentPage:1,
+  totalItems:1500,
+  itemsPerPage:100,
+  hasJumper:true,
+  jumperLabel:"Sayfaya Git",
+  hasSelect:true,
+  selectLabel:"Sayfa Başına",
+  selectOptions:JSON.stringify([
+  {
+    text: '100 Sonuç',
+    value: 100,
+  },
+  {
+    text: '250 Sonuç',
+    value: 250,
+  },
+  {
+    text: '500 Sonuç',
+    value: 500,
+  },
+  {
+    text: '1000 Sonuç',
+    value: 1000,
+  }]
+  )
+  }}>
     {PaginationTemplate.bind({})}
   </Story>
 </Canvas>

--- a/src/components/pagination/bl-pagination.stories.mdx
+++ b/src/components/pagination/bl-pagination.stories.mdx
@@ -44,11 +44,10 @@ import { Meta, Canvas, ArgsTable, Story, Preview, Source } from '@storybook/addo
         default:"Show"
       }
     },
-    selectOptions: {
+    itemsPerPageOptions: {
       control: {
         type: 'array',
-        default:
-          [
+        default:[
             {
               text: '100 Sonuç',
               value: 100,
@@ -79,7 +78,7 @@ export const PaginationTemplate = (args) => html`
       jumper-label=${ifDefined(args.jumperLabel)}
       has-select=${ifDefined(args.hasSelect)}
       select-label=${ifDefined(args.selectLabel)}
-      select-options=${ifDefined(args.selectOptions)}
+      .itemsPerPageOptions=${ifDefined(args.itemsPerPageOptions)}
       >
       </bl-pagination>
   `
@@ -128,7 +127,7 @@ The labels and the texts of the jumper and select element are fully customizable
   jumperLabel:"Sayfaya Git",
   hasSelect:true,
   selectLabel:"Sayfa Başına",
-  selectOptions:JSON.stringify([
+  itemsPerPageOptions:[
   {
     text: '100 Sonuç',
     value: 100,
@@ -145,7 +144,6 @@ The labels and the texts of the jumper and select element are fully customizable
     text: '1000 Sonuç',
     value: 1000,
   }]
-  )
   }}>
     {PaginationTemplate.bind({})}
   </Story>

--- a/src/components/pagination/bl-pagination.test.ts
+++ b/src/components/pagination/bl-pagination.test.ts
@@ -127,6 +127,15 @@ describe('bl-pagination', () => {
         expect(el.currentPage).to.equal(4);
       });
     });
+
+    it('renders only the current page with previous - next arrows on mobile view', async () => {
+      window.innerWidth = 600;
+      const el = await fixture<typeOfBlPagination>(
+        html`<bl-pagination current-page="10" items-per-page="1" total-items="10"></bl-pagination>`
+      );
+      expect(el.shadowRoot?.querySelectorAll('bl-button').length).to.eq(3);
+      expect(el.shadowRoot?.querySelectorAll('.dots').length).to.eq(0);
+    });
   });
 
   describe('jumper and select element', () => {

--- a/src/components/pagination/bl-pagination.test.ts
+++ b/src/components/pagination/bl-pagination.test.ts
@@ -32,7 +32,7 @@ describe('bl-pagination', () => {
   it('should render with the correct default values', async () => {
     const el = await fixture<typeOfBlPagination>(html`<bl-pagination></bl-pagination> `);
     expect(el?.currentPage).to.equal(1);
-    expect(el.itemsPerPage).to.equal(100);
+    expect(el.itemsPerPage).to.equal(10);
     expect(el.hasJumper).to.equal(false);
     expect(el.hasSelect).to.equal(false);
     expect(el.jumperLabel).to.equal('Go To');

--- a/src/components/pagination/bl-pagination.test.ts
+++ b/src/components/pagination/bl-pagination.test.ts
@@ -37,7 +37,6 @@ describe('bl-pagination', () => {
     expect(el.hasSelect).to.equal(false);
     expect(el.jumperLabel).to.equal('Go To');
     expect(el.selectLabel).to.equal('Show');
-    expect(el.optionText).to.equal('Items');
   });
 
   it('should correctly set the attributes', async () => {
@@ -51,7 +50,6 @@ describe('bl-pagination', () => {
           jumper-label="Git"
           has-select
           select-label="Göster"
-          option-text="Sonuç"
         >
         </bl-pagination>
       `
@@ -62,7 +60,6 @@ describe('bl-pagination', () => {
     expect(el.hasSelect).to.equal(true);
     expect(el.jumperLabel).to.equal('Git');
     expect(el.selectLabel).to.equal('Göster');
-    expect(el.optionText).to.equal('Sonuç');
   });
 
   describe('back and forward arrows', () => {

--- a/src/components/pagination/bl-pagination.ts
+++ b/src/components/pagination/bl-pagination.ts
@@ -12,25 +12,6 @@ import style from './bl-pagination.css';
  * @summary Baklava Pagination component
  */
 
-const selectOptions = [
-  {
-    text: '10 Items',
-    value: 10,
-  },
-  {
-    text: '25 Items',
-    value: 25,
-  },
-  {
-    text: '50 Items',
-    value: 50,
-  },
-  {
-    text: '100 Items',
-    value: 100,
-  },
-];
-
 @customElement('bl-pagination')
 export default class BlPagination extends LitElement {
   static get styles(): CSSResultGroup {
@@ -53,7 +34,7 @@ export default class BlPagination extends LitElement {
    * Sets the number of items per page
    */
   @property({ attribute: 'items-per-page', type: Number, reflect: true })
-  itemsPerPage = 100;
+  itemsPerPage = 10;
 
   /**
    * Adds jumper element if provided as true
@@ -80,10 +61,27 @@ export default class BlPagination extends LitElement {
   selectLabel = 'Show';
 
   /**
-   *  Sets the items per page options
+   *  Sets the items per page options of the select element
    */
   @property({ attribute: 'select-options', type: Array })
-  selectOptions = selectOptions;
+  selectOptions = [
+    {
+      text: '10 Items',
+      value: 10,
+    },
+    {
+      text: '25 Items',
+      value: 25,
+    },
+    {
+      text: '50 Items',
+      value: 50,
+    },
+    {
+      text: '100 Items',
+      value: 100,
+    },
+  ];
 
   @state() private pages: Array<number | string> = [];
 

--- a/src/components/pagination/bl-pagination.ts
+++ b/src/components/pagination/bl-pagination.ts
@@ -61,10 +61,11 @@ export default class BlPagination extends LitElement {
   selectLabel = 'Show';
 
   /**
-   *  Sets the items per page options of the select element
+   * Sets the items per page options of the select element
+   *  PROPERTY
    */
-  @property({ attribute: 'select-options', type: Array })
-  selectOptions = [
+  @property({ type: Array })
+  itemsPerPageOptions = [
     {
       text: '10 Items',
       value: 10,
@@ -89,6 +90,19 @@ export default class BlPagination extends LitElement {
    * Fires when the current page changes
    */
   @event('bl-change') private onChange: EventDispatcher<{ selectedPage: number; prevPage: number }>;
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    setTimeout(() => {
+      window?.addEventListener('resize', () => this._paginate());
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window?.removeEventListener('resize', this._paginate);
+  }
 
   updated(changedProperties: PropertyValues<this>) {
     if (
@@ -161,7 +175,7 @@ export default class BlPagination extends LitElement {
     this.currentPage = 1;
   }
 
-  private renderSinglePage(page: number | string) {
+  private _renderSinglePage(page: number | string) {
     if (typeof page === 'string') {
       return html`<span class="dots"></span>`;
     }
@@ -188,7 +202,9 @@ export default class BlPagination extends LitElement {
           ?disabled=${this.currentPage === 1}
         ></bl-button>
         <ul class="page-list">
-          ${this.pages.map(page => html`${this.renderSinglePage(page)}`)}
+          ${window.innerWidth < 768
+            ? html`${this._renderSinglePage(this.currentPage)}`
+            : this.pages.map(page => html`${this._renderSinglePage(page)}`)}
         </ul>
         <bl-button
           @click="${this._pageForward}"
@@ -208,7 +224,7 @@ export default class BlPagination extends LitElement {
           <div class="select">
             <label>${this.selectLabel}</label>
             <bl-select @bl-select="${this._selectHandler}">
-              ${this.selectOptions.map(option => {
+              ${this.itemsPerPageOptions.map(option => {
                 return html`<bl-select-option
                   value="${option.value}"
                   ?selected=${option.value === this.itemsPerPage}

--- a/src/components/pagination/bl-pagination.ts
+++ b/src/components/pagination/bl-pagination.ts
@@ -64,7 +64,7 @@ export default class BlPagination extends LitElement {
    * Sets the items per page options of the select element
    *  PROPERTY
    */
-  @property({ type: Array })
+  @property({ type: Array, attribute: false })
   itemsPerPageOptions = [
     {
       text: '10 Items',

--- a/src/components/pagination/bl-pagination.ts
+++ b/src/components/pagination/bl-pagination.ts
@@ -14,20 +14,20 @@ import style from './bl-pagination.css';
 
 const selectOptions = [
   {
-    text: '100',
+    text: '10 Items',
+    value: 10,
+  },
+  {
+    text: '25 Items',
+    value: 25,
+  },
+  {
+    text: '50 Items',
+    value: 50,
+  },
+  {
+    text: '100 Items',
     value: 100,
-  },
-  {
-    text: '250',
-    value: 250,
-  },
-  {
-    text: '500',
-    value: 500,
-  },
-  {
-    text: '1000',
-    value: 1000,
   },
 ];
 
@@ -80,10 +80,10 @@ export default class BlPagination extends LitElement {
   selectLabel = 'Show';
 
   /**
-   *  Sets the option texts.
+   *  Sets the items per page options
    */
-  @property({ attribute: 'option-text', type: String })
-  optionText = 'Items';
+  @property({ attribute: 'select-options', type: Array })
+  selectOptions = selectOptions;
 
   @state() private pages: Array<number | string> = [];
 
@@ -93,7 +93,11 @@ export default class BlPagination extends LitElement {
   @event('bl-change') private onChange: EventDispatcher<{ selectedPage: number; prevPage: number }>;
 
   updated(changedProperties: PropertyValues<this>) {
-    if (changedProperties.has('currentPage') || changedProperties.has('itemsPerPage') || changedProperties.has('totalItems') ) {
+    if (
+      changedProperties.has('currentPage') ||
+      changedProperties.has('itemsPerPage') ||
+      changedProperties.has('totalItems')
+    ) {
       this._paginate();
       this.onChange({
         selectedPage: this.currentPage,
@@ -201,20 +205,22 @@ export default class BlPagination extends LitElement {
   }
 
   render(): TemplateResult {
-    const selectEl = this.hasSelect ? html`
-      <div class="select">
-        <label>${this.selectLabel}</label>
-        <bl-select @bl-select="${this._selectHandler}">
-          ${selectOptions.map(option => {
-            return html`<bl-select-option
-              value="${option.value}"
-              ?selected=${option.value === this.itemsPerPage}
-              >${option.text} ${this.optionText}</bl-select-option
-            >`;
-          })}
-        </bl-select>
-      </div>
-    ` : null;
+    const selectEl = this.hasSelect
+      ? html`
+          <div class="select">
+            <label>${this.selectLabel}</label>
+            <bl-select @bl-select="${this._selectHandler}">
+              ${this.selectOptions.map(option => {
+                return html`<bl-select-option
+                  value="${option.value}"
+                  ?selected=${option.value === this.itemsPerPage}
+                  >${option.text}</bl-select-option
+                >`;
+              })}
+            </bl-select>
+          </div>
+        `
+      : null;
 
     const jumperEl = this.hasJumper
       ? html` <div class="jumper">
@@ -225,9 +231,7 @@ export default class BlPagination extends LitElement {
 
     const getHelperElements = () => {
       if (!this.hasSelect && !this.hasJumper) return;
-      return html`
-        <div class="pagination-helpers">${selectEl} ${jumperEl}</div>
-      `;
+      return html` <div class="pagination-helpers">${selectEl} ${jumperEl}</div> `;
     };
 
     return html` <div class="pagination">${getHelperElements()} ${this.renderPages()}</div>`;


### PR DESCRIPTION
Improvements:
* The "itemsPerPageOptions" array property is added,
* Default items-per-page is changed from 100 to 10,
* The "option-text" attribute is removed since the itemsPerPageOptions property includes texts and values,

The usage:
```
 <bl-pagination current-page="1" total-items="1500" 
</bl-pagination>

    pagination.itemsPerPageOptions = [
         {
        text: '100 Items',
        value: 100,
      },
      {
        text: '250 Items',
        value: 250,
      },
      {
        text: '500 Items',
        value: 500,
      },
      {
        text: '1000 Items',
        value: 1000,
      },
    ]

```

* Lastly, the component had no responsivity before, so little style changes are added.
 This part can be improved if @buseselvi has any feedbacks.

![image](https://user-images.githubusercontent.com/70342517/200294334-ec59d5ce-4a03-4fd5-8d53-2a5c5d29d2f8.png)

Closes #284.