### PR TITLE
fix(pagination): add item per page value bl-change event

### DIFF
--- a/src/components/pagination/bl-pagination.test.ts
+++ b/src/components/pagination/bl-pagination.test.ts
@@ -280,7 +280,10 @@ describe('bl-pagination', () => {
 
       select?.dispatchEvent(selectOptionEvent);
 
-      expect(el.itemsPerPage).to.equal(optionTwo?.value);
+      if (optionTwo) {
+        expect(el.itemsPerPage).to.equal(+optionTwo.value);
+      }
+
       expect(el.currentPage).to.equal(1);
 
       const undefinedEvent = new CustomEvent('bl-select', {

--- a/src/components/pagination/bl-pagination.ts
+++ b/src/components/pagination/bl-pagination.ts
@@ -89,7 +89,7 @@ export default class BlPagination extends LitElement {
   /**
    * Fires when the current page changes
    */
-  @event('bl-change') private onChange: EventDispatcher<{ selectedPage: number; prevPage: number }>;
+  @event('bl-change') private onChange: EventDispatcher<{ selectedPage: number; prevPage: number; itemsPerPage: number }>;
 
   connectedCallback() {
     super.connectedCallback();
@@ -114,6 +114,7 @@ export default class BlPagination extends LitElement {
       this.onChange({
         selectedPage: this.currentPage,
         prevPage: changedProperties.get('currentPage'),
+        itemsPerPage: this.itemsPerPage,
       });
     }
   }
@@ -171,7 +172,7 @@ export default class BlPagination extends LitElement {
   }
 
   private _selectHandler(event: CustomEvent) {
-    this.itemsPerPage = event?.detail[0]?.value || 100;
+    this.itemsPerPage = +event?.detail[0]?.value || 100;
     this.currentPage = 1;
   }
 


### PR DESCRIPTION
We should send to `itemsPerPage` value with `bl-change` event when select any item in `items per page` select  for fetching new list from api.