### PR TITLE
fix(pagination): throw events only on page & total-items changes

### DIFF
--- a/src/components/pagination/bl-pagination.ts
+++ b/src/components/pagination/bl-pagination.ts
@@ -89,7 +89,11 @@ export default class BlPagination extends LitElement {
   /**
    * Fires when the current page changes
    */
-  @event('bl-change') private onChange: EventDispatcher<{ selectedPage: number; prevPage: number; itemsPerPage: number }>;
+  @event('bl-change') private onChange: EventDispatcher<{
+    selectedPage: number;
+    prevPage: number;
+    itemsPerPage: number;
+  }>;
 
   connectedCallback() {
     super.connectedCallback();
@@ -111,6 +115,9 @@ export default class BlPagination extends LitElement {
       changedProperties.has('totalItems')
     ) {
       this._paginate();
+    }
+
+    if (changedProperties.get('currentPage') || changedProperties.get('itemsPerPage')) {
       this.onChange({
         selectedPage: this.currentPage,
         prevPage: changedProperties.get('currentPage'),


### PR DESCRIPTION
* Currently, pagination component throws bl-change event on first render cycle when no attribute (current-page, total-items and items-per-page) has changed.

* When the total-items changes on api calls, pagination re-renders and re-throw the event. This causes fetching duplicate data.

This pr fixes this issue by listening only the current-page and items-per-page changes.