### PR TITLE
fix: react wrapper for component files with multiple exports

### DIFF
--- a/scripts/generate-react-exports.js
+++ b/scripts/generate-react-exports.js
@@ -30,7 +30,9 @@ const baklavaReactFileParts = [];
 
 for (const module of customElementsModules) {
   const { declarations, path } = module;
-  const { events, name: componentName, tagName: fileName } = declarations[0];
+  const componentDeclaration = declarations.find(declaration => declaration.customElement === true);
+
+  const { events, name: componentName, tagName: fileName } = componentDeclaration;
 
   const eventNames = events
     ? events.reduce((acc, curr) => {


### PR DESCRIPTION
If a component file has multiple export statements, our react generator script fails to read component metadata, because it was checking the first export of the file. That was causing problem since radio component exports some other variables too.

Fixed it.