### PR TITLE
fix(alert): visual arrangements for alerts and font line-heights

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,4 +5,10 @@
 .innerZoomElementWrapper > * {
   vertical-align: top;
 }
+table {
+  width: 100%;
+}
+code {
+  font-size: 12px;
+}
 </style>

--- a/docs/customizing-baklava-theme.stories.mdx
+++ b/docs/customizing-baklava-theme.stories.mdx
@@ -101,3 +101,76 @@ Using design tokens here is of course also possible:
   --bl-badge-color: var(--bl-color-success);
 }
 ```
+
+## Customizing Typography Styles
+
+Baklava Design System provides many design tokens for typography. You can customize font styles in different levels according to your needs. For example:
+
+```css
+.my-header {
+  font: var(--bl-font-display-light);
+}
+```
+
+In the example above we are using "Display Light" font for an element. In your own theme, you can override this font definition like below:
+
+```css
+:root {
+  --bl-font-display-light: 400 40px/48px Helvetica;
+}
+```
+
+On the other hand, this variable uses multiple other variables behind the scene. Let's check how it's defined in our default theme:
+
+```css
+:root {
+  ...
+  --bl-font-display-font-size: var(--bl-font-size-5xl);
+  --bl-font-display-line-height: calc(var(--bl-font-display-font-size) + var(--bl-size-2xs));
+  --bl-font-display-size: var(--bl-font-display-font-size)/var(--bl-font-display-line-height);
+  --bl-font-display: var(--bl-font-display-size) var(--bl-font-family);
+  --bl-font-display-light: var(--bl-font-weight-light) var(--bl-font-display);
+  ...
+}
+```
+
+As you can see `--bl-font-display-light` is extending `--bl-font-display` by just setting font-weight with another variable we provide in design tokens
+named `--bl-font-weight-light`. It's also possible to override `--bl-font-display` to change font and size definitions of all of the "display" fonts
+without touching their font-weights:
+
+```css
+:root {
+  --bl-font-display: 40px/48px Helvetica;
+}
+```
+
+Same applies for other variables. Let's check how can we set custom line-heights.
+
+In Baklava typography line-height values are "font size + a value from the sizing list". For display font, `--bl-font-display-font-size` is set
+by `--bl-font-size-5xl` and this value is summed with `--bl-size-2xs` while setting `--bl-font-display-line-height`. You are able customize this
+logic in any level you want.
+
+```css
+:root {
+  --bl-font-display-line-height: 68px;
+}
+```
+
+Or an element level like:
+
+```css
+.my-header {
+  font: var(--bl-font-display-light);
+  --bl-font-display-line-height: 68px;
+}
+```
+
+Or you can set just font size:
+```css
+.my-header {
+  font: var(--bl-font-display-light);
+  --bl-font-display-font-size: 60px;
+}
+```
+
+In this case line-height of my-header will be set as 60px + value of `--bl-size-2xs`. Line-height is still calculated automatically.

--- a/docs/design-system/typography.stories.mdx
+++ b/docs/design-system/typography.stories.mdx
@@ -14,10 +14,9 @@ Typography creates purposeful texture, guiding users to read and understand the 
 
 The default font is **Rubik** in Baklava Design System. You can give any typography variable in your code like this:
 
-
 ```css
 .my-header {
-    font: var(--bl-font-display-light);
+  font: var(--bl-font-display-light);
 }
 ```
 
@@ -25,23 +24,23 @@ The default font is **Rubik** in Baklava Design System. You can give any typogra
 
 A display fonts is a font that is intended for use at large sizes for headings. Often used on landing pages.
 
-| <div style={{ width: '15rem' }}>Variable</div> | <div style={{ width: '20rem' }}>Styles</div>  | <div style={{ width: '25rem' }}>Example</div>  |
-|:-----------------------:|:-------------:|:----------:|
-| --bl-font-display-light | Font Family: Rubik <br/> Weight: 300 / Light <br/> Size: 48px / 3rem | <h1 style={{ font: 'var(--bl-font-display-light)' }}>Display Light</h1> |
-| --bl-font-display-regular | Font Family: Rubik <br/> Weight: 400 / Regular <br/> Size: 48px / 3rem | <h1 style={{ font: 'var(--bl-font-display-regular)' }}>Display Regular</h1> |
-| --bl-font-display-medium | Font Family: Rubik <br/> Weight: 500 / Medium <br/> Size: 48px / 3rem | <h1 style={{ font: 'var(--bl-font-display-medium)' }}>Display Medium</h1> |
-| --bl-font-display-semibold | Font Family: Rubik <br/> Weight: 600 / Semibold <br/> Size: 48px / 3rem | <h1 style={{ font: 'var(--bl-font-display-semibold)' }}>Display Semibold</h1> |
-| --bl-font-display-bold | Font Family: Rubik <br/> Weight: 700 / Bold <br/> Size: 48px / 3rem | <h1 style={{ font: 'var(--bl-font-display-bold)' }}>Display Bold</h1> |
+| Variable | Styles | Example |
+|:---------|:-------|:-------:|
+| `--bl-font-display-light` | Weight: 300 / Light <br/> Size: 48px / 3rem  <br/> Height: 56px (font size + `bl-size-2xs`) | <h1 style={{ font: 'var(--bl-font-display-light)' }}>Display Light</h1> |
+| `--bl-font-display-regular` | Weight: 400 / Regular <br/> Size: 48px / 3rem  <br/> Height: 56px (font size + `bl-size-2xs`) | <h1 style={{ font: 'var(--bl-font-display-regular)' }}>Display Regular</h1> |
+| `--bl-font-display-medium` | Weight: 500 / Medium <br/> Size: 48px / 3rem  <br/> Height: 56px (font size + `bl-size-2xs`) | <h1 style={{ font: 'var(--bl-font-display-medium)' }}>Display Medium</h1> |
+| `--bl-font-display-semibold` | Weight: 600 / Semibold <br/> Size: 48px / 3rem  <br/> Height: 56px (font size + `bl-size-2xs`) | <h1 style={{ font: 'var(--bl-font-display-semibold)' }}>Display Semibold</h1> |
+| `--bl-font-display-bold` | Weight: 700 / Bold <br/> Size: 48px / 3rem  <br/> Height: 56px (font size + `bl-size-2xs`) | <h1 style={{ font: 'var(--bl-font-display-bold)' }}>Display Bold</h1> |
 
 ## Headings
 
 Heading fonts are used as larger, higher impact text, such as in a title or section header.
 
-| <div style={{ width: '15rem' }}>Variable</div> | <div style={{ width: '20rem' }}>Styles</div>  | <div style={{ width: '25rem' }}>Example</div>  |
-|:-----------------------:|:-------------:|:----------:|
-| --bl-font-heading-1 | Font Family: Rubik <br/> Weight: 300 / Light <br/> Size: 32px / 2rem | <h1 style={{ font: 'var(--bl-font-heading-1)' }}>Heading 1</h1> |
-| --bl-font-heading-2 | Font Family: Rubik <br/> Weight: 400 / Regular <br/> Size: 28px / 1.75rem | <h1 style={{ font: 'var(--bl-font-heading-2)' }}>Heading 2</h1> |
-| --bl-font-heading-3 | Font Family: Rubik <br/> Weight: 400 / Regular <br/> Size: 24px / 1.5rem | <h1 style={{ font: 'var(--bl-font-heading-3)' }}>Heading 3</h1> |
+| Variable | Styles | Example |
+|:---------|:-------|:-------:|
+| `--bl-font-heading-1` | Weight: 300 / Light <br/> Size: 32px / 2rem <br/> Height: 36px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-heading-1)' }}>Heading 1</h1> |
+| `--bl-font-heading-2` | Weight: 400 / Regular <br/> Size: 28px / 1.75rem <br/> Height: 32px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-heading-2)' }}>Heading 2</h1> |
+| `--bl-font-heading-3` | Weight: 400 / Regular <br/> Size: 24px / 1.5rem <br/> Height: 28px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-heading-3)' }}>Heading 3</h1> |
 
 ## Sub Titles
 
@@ -49,59 +48,59 @@ Subtitles are smaller than headlines. They are typically reserved for medium-emp
 
 #### Sub Title 1
 
-| <div style={{ width: '15rem' }}>Variable</div> | <div style={{ width: '20rem' }}>Styles</div>  | <div style={{ width: '25rem' }}>Example</div>  |
-|:-----------------------:|:-------------:|:----------:|
-| --bl-font-title-1-regular | Font Family: Rubik <br/> Weight: 400 / Regular <br/> Size: 20px / 1.25rem | <h1 style={{ font: 'var(--bl-font-title-1-regular)' }}>Sub Title 1 Regular</h1> |
-| --bl-font-title-1-medium  | Font Family: Rubik <br/> Weight: 500 / Medium <br/> Size: 20px / 1.25rem | <h1 style={{ font: 'var(--bl-font-title-1-medium)' }}>Sub Title 1 Medium</h1> |
-| --bl-font-title-1-semibold  | Font Family: Rubik <br/> Weight: 600 / Semibold <br/> Size: 20px / 1.25rem | <h1 style={{ font: 'var(--bl-font-title-1-semibold)' }}>Sub Title 1 Semibold</h1> |
-| --bl-font-title-1-bold  | Font Family: Rubik <br/> Weight: 700 / Bold <br/> Size: 20px / 1.25rem | <h1 style={{ font: 'var(--bl-font-title-1-bold)' }}>Sub Title 1 Bold</h1> |
+| Variable | Styles | Example |
+|:---------|:-------|:-------:|
+| `--bl-font-title-1-regular`| Weight: 400 / Regular <br/> Size: 20px / 1.25rem <br/> Height: 24px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-title-1-regular)' }}>Sub Title 1 Regular</h1> |
+| `--bl-font-title-1-medium` | Weight: 500 / Medium <br/> Size: 20px / 1.25rem <br/> Height: 24px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-title-1-medium)' }}>Sub Title 1 Medium</h1> |
+| `--bl-font-title-1-semibold` | Weight: 600 / Semibold <br/> Size: 20px / 1.25rem <br/> Height: 24px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-title-1-semibold)' }}>Sub Title 1 Semibold</h1> |
+| `--bl-font-title-1-bold` | Weight: 700 / Bold <br/> Size: 20px / 1.25rem <br/> Height: 24px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-title-1-bold)' }}>Sub Title 1 Bold</h1> |
 
 #### Sub Title 2
 
-| <div style={{ width: '15rem' }}>Variable</div> | <div style={{ width: '20rem' }}>Styles</div>  | <div style={{ width: '25rem' }}>Example</div>  |
-|:-----------------------:|:-------------:|:----------:|
-| --bl-font-title-2-regular | Font Family: Rubik <br/> Weight: 400 / Regular <br/> Size: 16px / 1rem | <h1 style={{ font: 'var(--bl-font-title-2-regular)' }}>Sub Title 2 Regular</h1> |
-| --bl-font-title-2-medium  | Font Family: Rubik <br/> Weight: 500 / Medium <br/> Size: 16px / 1rem | <h1 style={{ font: 'var(--bl-font-title-2-medium)' }}>Sub Title 2 Medium</h1> |
-| --bl-font-title-2-semibold  | Font Family: Rubik <br/> Weight: 600 / Semibold <br/> Size: 16px / 1rem | <h1 style={{ font: 'var(--bl-font-title-2-semibold)' }}>Sub Title 2 Semibold</h1> |
-| --bl-font-title-2-bold  | Font Family: Rubik <br/> Weight: 700 / Bold <br/> Size: 16px / 1rem | <h1 style={{ font: 'var(--bl-font-title-2-bold)' }}>Sub Title 2 Bold</h1> |
+| Variable | Styles | Example |
+|:---------|:-------|:-------:|
+| `--bl-font-title-2-regula` | Weight: 400 / Regular <br/> Size: 16px / 1rem <br/> Height: 20px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-title-2-regular)' }}>Sub Title 2 Regular</h1> |
+| `--bl-font-title-2-medium` | Weight: 500 / Medium <br/> Size: 16px / 1rem <br/> Height: 20px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-title-2-medium)' }}>Sub Title 2 Medium</h1> |
+| `--bl-font-title-2-semibold` | Weight: 600 / Semibold <br/> Size: 16px / 1rem <br/> Height: 20px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-title-2-semibold)' }}>Sub Title 2 Semibold</h1> |
+| `--bl-font-title-2-bold` | Weight: 700 / Bold <br/> Size: 16px / 1rem <br/> Height: 20px (font size + `bl-size-3xs`) | <h1 style={{ font: 'var(--bl-font-title-2-bold)' }}>Sub Title 2 Bold</h1> |
 
 #### Sub Title 3
 
-| <div style={{ width: '15rem' }}>Variable</div> | <div style={{ width: '20rem' }}>Styles</div>  | <div style={{ width: '25rem' }}>Example</div>  |
-|:-----------------------:|:-------------:|:----------:|
-| --bl-font-title-3-regular | Font Family: Rubik <br/> Weight: 400 / Regular <br/> Size: 14px / 0.875rem | <h1 style={{ font: 'var(--bl-font-title-3-regular)' }}>Sub Title 3 Regular</h1> |
-| --bl-font-title-3-medium  | Font Family: Rubik <br/> Weight: 500 / Medium <br/> Size: 14px / 0.875rem | <h1 style={{ font: 'var(--bl-font-title-3-medium)' }}>Sub Title 3 Medium</h1> |
-| --bl-font-title-3-semibold  | Font Family: Rubik <br/> Weight: 600 / Semibold <br/> Size: 14px / 0.875rem | <h1 style={{ font: 'var(--bl-font-title-3-semibold)' }}>Sub Title 3 Semibold</h1> |
-| --bl-font-title-3-bold  | Font Family: Rubik <br/> Weight: 700 / Bold <br/> Size: 14px / 0.875rem | <h1 style={{ font: 'var(--bl-font-title-3-bold)' }}>Sub Title 3 Bold</h1> |
+| Variable | Styles | Example |
+|:---------|:-------|:-------:|
+| `--bl-font-title-3-regular` | Weight: 400 / Regular <br/> Size: 14px / 0.875rem <br/> Height: 16px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-title-3-regular)' }}>Sub Title 3 Regular</h1> |
+| `--bl-font-title-3-medium` | Weight: 500 / Medium <br/> Size: 14px / 0.875rem <br/> Height: 16px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-title-3-medium)' }}>Sub Title 3 Medium</h1> |
+| `--bl-font-title-3-semibold` | Weight: 600 / Semibold <br/> Size: 14px / 0.875rem <br/> Height: 16px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-title-3-semibold)' }}>Sub Title 3 Semibold</h1> |
+| `--bl-font-title-3-bold` | Weight: 700 / Bold <br/> Size: 14px / 0.875rem <br/> Height: 16px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-title-3-bold)' }}>Sub Title 3 Bold</h1> |
 
 #### Sub Title 4
 
-| <div style={{ width: '15rem' }}>Variable</div> | <div style={{ width: '20rem' }}>Styles</div>  | <div style={{ width: '25rem' }}>Example</div>  |
-|:-----------------------:|:-------------:|:----------:|
-| --bl-font-title-4-regular | Font Family: Rubik <br/> Weight: 400 / Regular <br/> Size: 12px / 0.75rem | <h1 style={{ font: 'var(--bl-font-title-4-regular)' }}>Sub Title 4 Regular</h1> |
-| --bl-font-title-4-medium  | Font Family: Rubik <br/> Weight: 500 / Medium <br/> Size: 12px / 0.75rem | <h1 style={{ font: 'var(--bl-font-title-4-medium)' }}>Sub Title 4 Medium</h1> |
-| --bl-font-title-4-semibold  | Font Family: Rubik <br/> Weight: 600 / Semibold <br/> Size: 12px / 0.75rem | <h1 style={{ font: 'var(--bl-font-title-4-semibold)' }}>Sub Title 4 Semibold</h1> |
-| --bl-font-title-4-bold  | Font Family: Rubik <br/> Weight: 700 / Bold <br/> Size: 12px / 0.75rem | <h1 style={{ font: 'var(--bl-font-title-4-bold)' }}>Sub Title 4 Bold</h1> |
+| Variable | Styles | Example |
+|:---------|:-------|:-------:|
+| `--bl-font-title-4-regular` | Weight: 400 / Regular <br/> Size: 12px / 0.75rem <br/> Height: 14px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-title-4-regular)' }}>Sub Title 4 Regular</h1> |
+| `--bl-font-title-4-medium` | Weight: 500 / Medium <br/> Size: 12px / 0.75rem <br/> Height: 14px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-title-4-medium)' }}>Sub Title 4 Medium</h1> |
+| `--bl-font-title-4-semibold` | Weight: 600 / Semibold <br/> Size: 12px / 0.75rem <br/> Height: 14px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-title-4-semibold)' }}>Sub Title 4 Semibold</h1> |
+| `--bl-font-title-4-bold` | Weight: 700 / Bold <br/> Size: 12px / 0.75rem <br/> Height: 14px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-title-4-bold)' }}>Sub Title 4 Bold</h1> |
 
 
 ## Body Texts
 
 Body text typically used for long-form writing as it works well for small text sizes.
 
-| <div style={{ width: '15rem' }}>Variable</div> | <div style={{ width: '20rem' }}>Styles</div>  | <div style={{ width: '25rem' }}>Example</div>  |
-|:-----------------------:|:-------------:|:----------:|
-| --bl-font-body-text-1 |  Font Family: Rubik <br/>   Weight: 400 / Regular <br/> Size: 16px / 1rem | <h1 style={{ font: 'var(--bl-font-body-text-1)' }}>Form Body Text 1</h1> |
-| --bl-font-body-text-2 |  Font Family: Rubik <br/>   Weight: 400 / Regular <br/> Size: 14px / 0.875rem | <h1 style={{ font: 'var(--bl-font-body-text-2)' }}>Form Body Text 2</h1> |
-| --bl-font-body-text-3 |  Font Family: Rubik <br/>   Weight: 400 / Regular <br/> Size: 12px / 0.75rem | <h1 style={{ font: 'var(--bl-font-body-text-3)' }}>Form Body Text 3</h1> |
+| Variable | Styles | Example |
+|:---------|:-------|:-------:|
+| `--bl-font-body-text-1` | Weight: 400 / Regular <br/> Size: 16px / 1rem <br/> Height: 18px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-body-text-1)' }}>Form Body Text 1</h1> |
+| `--bl-font-body-text-2` | Weight: 400 / Regular <br/> Size: 14px / 0.875rem <br/> Height: 16px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-body-text-2)' }}>Form Body Text 2</h1> |
+| `--bl-font-body-text-3` | Weight: 400 / Regular <br/> Size: 12px / 0.75rem  <br/> Height: 14px (font size + `bl-size-4xs`)| <h1 style={{ font: 'var(--bl-font-body-text-3)' }}>Form Body Text 3</h1> |
 
 
 ## Captions
 
 Caption is the smallest font size. They are mostly used for labels.
 
-| <div style={{ width: '15rem' }}>Variable</div> | <div style={{ width: '20rem' }}>Styles</div>  | <div style={{ width: '25rem' }}>Example</div>  |
-|:-----------------------:|:-------------:|:----------:|
-| --bl-font-caption |  Font Family: Rubik <br/>   Weight: 500 / Medium <br/> Size: 10px / 0.625rem | <h1 style={{ font: 'var(--bl-font-caption)' }}>Caption</h1> |
+| Variable | Styles | Example |
+|:---------|:-------|:-------:|
+| `--bl-font-caption` | Weight: 500 / Medium <br/> Size: 10px / 0.625rem <br/> Height: 12px (font size + `bl-size-4xs`) | <h1 style={{ font: 'var(--bl-font-caption)' }}>Caption</h1> |
 
 ## CSS Variables
 

--- a/src/components/alert/bl-alert.css
+++ b/src/components/alert/bl-alert.css
@@ -13,9 +13,10 @@
   justify-content: space-between;
   background-color: var(--main-bg-color);
   color: var(--bl-color-content-primary);
-  box-shadow: 0 0 0 1px var(--main-color);
+  box-shadow: inset 0 0 0 1px var(--main-color);
   border-radius: var(--bl-border-radius-s);
   padding: calc(var(--padding) / 2) var(--padding);
+  padding-right: calc(var(--padding) / 2);
 }
 
 .description {
@@ -50,7 +51,6 @@
 .caption {
   color: var(--bl-color-content-primary);
   font: var(--bl-font-title-3-medium);
-  margin-bottom: var(--bl-size-4xs);
 }
 
 .action {
@@ -61,10 +61,6 @@
 
 .caption + .description {
   margin-top: var(--bl-size-2xs);
-}
-
-.close-spaced {
-  margin-top: calc(var(--padding) / 2);
 }
 
 :host([closed]) {

--- a/src/components/alert/bl-alert.css
+++ b/src/components/alert/bl-alert.css
@@ -19,7 +19,7 @@
 }
 
 .description {
-  font: var(--bl-font-title-3-regular);
+  font: var(--bl-font-body-text-2);
 }
 
 .wrapper {

--- a/src/components/alert/bl-alert.css
+++ b/src/components/alert/bl-alert.css
@@ -32,7 +32,6 @@
 
 .content {
   display: flex;
-  align-items: center;
   padding: calc(var(--padding) / 2) 0;
   margin-right: var(--bl-size-2xs);
   flex: 20 1 70%;
@@ -49,7 +48,7 @@
 }
 
 .caption {
-  color: var(--main-color);
+  color: var(--bl-color-content-primary);
   font: var(--bl-font-title-3-medium);
   margin-bottom: var(--bl-size-4xs);
 }
@@ -61,7 +60,7 @@
 }
 
 .caption + .description {
-  font: var(--bl-font-body-text-3);
+  margin-top: var(--bl-size-2xs);
 }
 
 .close-spaced {

--- a/src/components/alert/bl-alert.ts
+++ b/src/components/alert/bl-alert.ts
@@ -6,7 +6,6 @@ import '../icon/bl-icon';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { stringBooleanConverter } from '../../utilities/string-boolean.converter';
 import { ButtonVariant, ButtonKind, ButtonSize } from '../button/bl-button';
-import { classMap } from 'lit/directives/class-map.js';
 
 export type AlertVariant = 'info' | 'warning' | 'success' | 'danger';
 
@@ -127,14 +126,9 @@ export default class BlAlert extends LitElement {
       ? html`<bl-icon class="icon" name=${ifDefined(this._getIcon())}></bl-icon>`
       : null;
 
-    const closeClasses = classMap({
-      'close': true,
-      'close-spaced': !!caption,
-    });
-
     const closable = this.closable
       ? html`<bl-button
-          class=${closeClasses}
+          class="close"
           label="close"
           variant="tertiary"
           kind="neutral"

--- a/src/components/checkbox-group/checkbox/bl-checkbox.css
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.css
@@ -33,6 +33,7 @@ input {
   border-radius: var(--bl-border-radius-xs);
   color: var(--bl-color-content-primary-contrast);
   font-size: var(--bl-font-size-2xs);
+  line-height: 100%;
 }
 
 :host([checked]) .label,

--- a/src/themes/default.css
+++ b/src/themes/default.css
@@ -86,7 +86,10 @@
   --bl-border-radius-circle: 50%;
 
   /* Font Style: Display */
-  --bl-font-display: var(--bl-font-size-5xl) var(--bl-font-family);
+  --bl-font-display-font-size: var(--bl-font-size-5xl);
+  --bl-font-display-line-height: calc(var(--bl-font-display-font-size) + var(--bl-size-2xs));
+  --bl-font-display-size: var(--bl-font-display-font-size)/var(--bl-font-display-line-height);
+  --bl-font-display: var(--bl-font-display-size) var(--bl-font-family);
   --bl-font-display-light: var(--bl-font-weight-light) var(--bl-font-display);
   --bl-font-display-regular: var(--bl-font-weight-regular) var(--bl-font-display);
   --bl-font-display-medium: var(--bl-font-weight-medium) var(--bl-font-display);
@@ -94,51 +97,84 @@
   --bl-font-display-bold: var(--bl-font-weight-bold) var(--bl-font-display);
 
   /* Font Style: Heading 1 */
-  --bl-font-heading-1: var(--bl-font-weight-light) var(--bl-font-size-4xl) var(--bl-font-family);
+  --bl-font-heading-1-font-size: var(--bl-font-size-4xl);
+  --bl-font-heading-1-line-height: calc(var(--bl-font-heading-1-font-size) + var(--bl-size-3xs));
+  --bl-font-heading-1-size: var(--bl-font-heading-1-font-size)/var(--bl-font-heading-1-line-height);
+  --bl-font-heading-1: var(--bl-font-weight-light) var(--bl-font-heading-1-size) var(--bl-font-family);
 
    /* Font Style: Heading 2 */
-   --bl-font-heading-2: var(--bl-font-weight-regular) var(--bl-font-size-3xl) var(--bl-font-family);
+   --bl-font-heading-2-font-size: var(--bl-font-size-3xl);
+   --bl-font-heading-2-line-height: calc(var(--bl-font-heading-2-font-size) + var(--bl-size-3xs));
+   --bl-font-heading-2-size: var(--bl-font-heading-2-font-size)/var(--bl-font-heading-2-line-height);
+   --bl-font-heading-2: var(--bl-font-weight-regular) var(--bl-font-heading-2-size) var(--bl-font-family);
 
    /* Font Style: Heading 3 */
-   --bl-font-heading-3: var(--bl-font-weight-regular) var(--bl-font-size-2xl) var(--bl-font-family);
+   --bl-font-heading-3-font-size: var(--bl-font-size-2xl);
+   --bl-font-heading-3-line-height: calc(var(--bl-font-heading-3-font-size) + var(--bl-size-3xs));
+   --bl-font-heading-3-size: var(--bl-font-heading-3-font-size)/var(--bl-font-heading-3-line-height);
+   --bl-font-heading-3: var(--bl-font-weight-regular) var(--bl-font-heading-3-size) var(--bl-font-family);
 
   /* Font Style: Title 1 */
-  --bl-font-title-1: var(--bl-font-size-xl) var(--bl-font-family);
+  --bl-font-title-1-font-size: var(--bl-font-size-xl);
+  --bl-font-title-1-line-height: calc(var(--bl-font-title-1-font-size) + var(--bl-size-3xs));
+  --bl-font-title-1-size: var(--bl-font-title-1-font-size)/var(--bl-font-title-1-line-height);
+  --bl-font-title-1: var(--bl-font-title-1-size) var(--bl-font-family);
   --bl-font-title-1-regular: var(--bl-font-weight-regular) var(--bl-font-title-1);
   --bl-font-title-1-medium: var(--bl-font-weight-medium) var(--bl-font-title-1);
   --bl-font-title-1-semibold: var(--bl-font-weight-semibold) var(--bl-font-title-1);
   --bl-font-title-1-bold: var(--bl-font-weight-bold) var(--bl-font-title-1);
 
   /* Font Style: Title 2 */
-  --bl-font-title-2: var(--bl-font-size-l) var(--bl-font-family);
+  --bl-font-title-2-font-size: var(--bl-font-size-l);
+  --bl-font-title-2-line-height: calc(var(--bl-font-title-2-font-size) + var(--bl-size-3xs));
+  --bl-font-title-2-size: var(--bl-font-title-2-font-size)/var(--bl-font-title-2-line-height);
+  --bl-font-title-2: var(--bl-font-title-2-size) var(--bl-font-family);
   --bl-font-title-2-regular: var(--bl-font-weight-regular) var(--bl-font-title-2);
   --bl-font-title-2-medium: var(--bl-font-weight-medium) var(--bl-font-title-2);
   --bl-font-title-2-semibold: var(--bl-font-weight-semibold) var(--bl-font-title-2);
   --bl-font-title-2-bold: var(--bl-font-weight-bold) var(--bl-font-title-2);
 
   /* Font Style: Title 3 */
-  --bl-font-title-3: var(--bl-font-size-m) var(--bl-font-family);
+  --bl-font-title-3-font-size: var(--bl-font-size-m);
+  --bl-font-title-3-line-height: calc(var(--bl-font-title-3-font-size) + var(--bl-size-4xs));
+  --bl-font-title-3-size: var(--bl-font-title-3-font-size)/var(--bl-font-title-3-line-height);
+  --bl-font-title-3: var(--bl-font-title-3-size) var(--bl-font-family);
   --bl-font-title-3-regular: var(--bl-font-weight-regular) var(--bl-font-title-3);
   --bl-font-title-3-medium: var(--bl-font-weight-medium) var(--bl-font-title-3);
   --bl-font-title-3-semibold: var(--bl-font-weight-semibold) var(--bl-font-title-3);
   --bl-font-title-3-bold: var(--bl-font-weight-bold) var(--bl-font-title-3);
 
   /* Font Style: Title 4 */
-  --bl-font-title-4: var(--bl-font-size-s) var(--bl-font-family);
+  --bl-font-title-4-font-size: var(--bl-font-size-s);
+  --bl-font-title-4-line-height: calc(var(--bl-font-title-4-font-size) + var(--bl-size-4xs));
+  --bl-font-title-4-size: var(--bl-font-title-4-font-size)/var(--bl-font-title-4-line-height);
+  --bl-font-title-4: var(--bl-font-title-4-size) var(--bl-font-family);
   --bl-font-title-4-regular: var(--bl-font-weight-regular) var(--bl-font-title-4);
   --bl-font-title-4-medium: var(--bl-font-weight-medium) var(--bl-font-title-4);
   --bl-font-title-4-semibold: var(--bl-font-weight-semibold) var(--bl-font-title-4);
   --bl-font-title-4-bold: var(--bl-font-weight-bold) var(--bl-font-title-4);
 
   /* Font Style: Body Text 1 */
-  --bl-font-body-text-1: var(--bl-font-weight-regular) var(--bl-font-size-l) var(--bl-font-family);
+  --bl-font-body-text-1-font-size: var(--bl-font-size-l);
+  --bl-font-body-text-1-line-height: calc(var(--bl-font-body-text-1-font-size) + var(--bl-size-4xs));
+  --bl-font-body-text-1-size: var(--bl-font-body-text-1-font-size)/var(--bl-font-body-text-1-line-height);
+  --bl-font-body-text-1: var(--bl-font-weight-regular) var(--bl-font-body-text-1-size) var(--bl-font-family);
 
   /* Font Style: Body Text 2 */
-  --bl-font-body-text-2: var(--bl-font-weight-regular) var(--bl-font-size-m) var(--bl-font-family);
+  --bl-font-body-text-2-font-size: var(--bl-font-size-m);
+  --bl-font-body-text-2-line-height: calc(var(--bl-font-body-text-2-font-size) + var(--bl-size-4xs));
+  --bl-font-body-text-2-size: var(--bl-font-body-text-2-font-size)/var(--bl-font-body-text-2-line-height);
+  --bl-font-body-text-2: var(--bl-font-weight-regular) var(--bl-font-body-text-2-size) var(--bl-font-family);
 
   /* Font Style: Body Text 3 */
-  --bl-font-body-text-3: var(--bl-font-weight-regular) var(--bl-font-size-s) var(--bl-font-family);
+  --bl-font-body-text-3-font-size: var(--bl-font-size-s);
+  --bl-font-body-text-3-line-height: calc(var(--bl-font-body-text-3-font-size) + var(--bl-size-4xs));
+  --bl-font-body-text-3-size: var(--bl-font-body-text-3-font-size)/var(--bl-font-body-text-3-line-height);
+  --bl-font-body-text-3: var(--bl-font-weight-regular) var(--bl-font-body-text-3-size) var(--bl-font-family);
 
   /* Font Style: Caption */
-  --bl-font-caption: var(--bl-font-weight-medium) var(--bl-font-size-xs) var(--bl-font-family);
+  --bl-font-caption-font-size: var(--bl-font-size-s);
+  --bl-font-caption-line-height: calc(var(--bl-font-caption-font-size) + var(--bl-size-4xs));
+  --bl-font-caption-size: var(--bl-font-caption-font-size)/var(--bl-font-caption-line-height);
+  --bl-font-caption: var(--bl-font-weight-medium) var(--bl-font-caption-size) var(--bl-font-family);
 }


### PR DESCRIPTION
Some visual updates on our Alert component regarding to our updated [Figma document](https://www.figma.com/file/RrcLH0mWpIUy4vwuTlDeKN/Baklava-Design-Guide?node-id=2815%3A14630&t=GYqRcNG6DYvgT0Nn-0).

I made some big changes here by setting line-heights for our typography rules -again-. This was needed to have consistent heights on alert component. I used some new set of css tokens in our default theme file. I added some documents about how to customise them.

Closes #318 