### PR TITLE
fix(select): visual fixes over long texts

### DIFF
--- a/src/components/checkbox-group/checkbox/bl-checkbox.css
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.css
@@ -9,12 +9,15 @@
 
 label {
   display: flex;
-  align-items: center;
   gap: var(--bl-size-2xs);
   color: var(--bl-color-secondary);
   font: var(--bl-font-title-3);
   cursor: pointer;
   user-select: none;
+}
+
+.label {
+  word-break: break-all;
 }
 
 input {
@@ -29,10 +32,15 @@ input {
   box-sizing: border-box;
   width: var(--bl-size-m);
   height: var(--bl-size-m);
+  min-width: var(--bl-size-m);
+  min-height: var(--bl-size-m);
+  max-width: var(--bl-size-m);
+  max-height: var(--bl-size-m);
   border: 1px solid var(--bl-color-border);
   border-radius: var(--bl-border-radius-xs);
   color: var(--bl-color-content-primary-contrast);
   font-size: var(--bl-font-size-2xs);
+  background-color: var(--bl-color-primary-background);
 }
 
 :host([checked]) .label,

--- a/src/components/checkbox-group/checkbox/bl-checkbox.stories.mdx
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.stories.mdx
@@ -30,16 +30,17 @@ import { Meta, Canvas, ArgsTable, Story } from '@storybook/addon-docs';
   }}
 />
 
-export const CheckboxTemplate = (args) => html`
-<bl-checkbox
-    ?disabled=${args.disabled}
-    ?checked=${args.checked}
-    name='${ifDefined(args.name)}'
-    value='${ifDefined(args.value)}'
-    ?indeterminate=${args.indeterminate}
-    ?required=${args.required}>
-    ${args.label}
-  </bl-checkbox>
+export const CheckboxTemplate = (args) => html`<bl-checkbox
+  ?disabled=${args.disabled}
+  ?checked=${args.checked}
+  name='${ifDefined(args.name)}'
+  value='${ifDefined(args.value)}'
+  ?indeterminate=${args.indeterminate}
+  ?required=${args.required}>${args.label}</bl-checkbox>`;
+
+export const CheckboxLimitedWidthTemplate = (args) => html`<div style="max-width: 100px">
+  ${CheckboxTemplate(args)}
+</div>
 `;
 
 # Checkbox
@@ -121,6 +122,26 @@ Provide the name and the value of the checkbox element, so that its value can be
     {CheckboxTemplate.bind({})}
   </Story>
 </Canvas>
+
+## Multiline labels
+
+If label doesn't fit the row and goes multiline, checkmark stays on top.
+
+<Canvas>
+  <Story name="Multiline label" args={{ label: "Very long label that doesn't fit single line" }}>
+    {CheckboxLimitedWidthTemplate.bind({})}
+  </Story>
+</Canvas>
+
+Also if a single word doesn't fit the line, it also being forced to multiline (with `word-break: break-all;`).
+
+
+<Canvas>
+  <Story name="A very long word" args={{ label: "Some/Very&LongSingleWord" }}>
+    {CheckboxLimitedWidthTemplate.bind({})}
+  </Story>
+</Canvas>
+
 
 ## Reference
 

--- a/src/components/checkbox-group/checkbox/bl-checkbox.stories.mdx
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.stories.mdx
@@ -40,8 +40,11 @@ export const CheckboxTemplate = (args) => html`<bl-checkbox
 
 export const CheckboxLimitedWidthTemplate = (args) => html`<div style="max-width: 100px">
   ${CheckboxTemplate(args)}
-</div>
-`;
+</div>`;
+
+export const CheckboxDifferentBackgroundTemplate = (args) => html`<div style="padding: 20px; background-color: var(--bl-color-accent-primary-background);">
+  ${CheckboxTemplate(args)}
+</div>`;
 
 # Checkbox
 Checkbox component can be used to control checked / unchecked statuses.
@@ -57,9 +60,12 @@ Use checkbox component for getting true/false input from users.
 
 You can show label by just using slot.
 
-<Canvas>
+<Canvas isColumn>
   <Story name="Basic Usage" args={{ label: 'Label' }}>
     {CheckboxTemplate.bind({})}
+  </Story>
+  <Story name="Basic Usage with Different Background color" args={{ label: 'Label' }}>
+    {CheckboxDifferentBackgroundTemplate.bind({})}
   </Story>
 </Canvas>
 
@@ -134,7 +140,6 @@ If label doesn't fit the row and goes multiline, checkmark stays on top.
 </Canvas>
 
 Also if a single word doesn't fit the line, it also being forced to multiline (with `word-break: break-all;`).
-
 
 <Canvas>
   <Story name="A very long word" args={{ label: "Some/Very&LongSingleWord" }}>

--- a/src/components/select/bl-select.css
+++ b/src/components/select/bl-select.css
@@ -200,6 +200,7 @@ label {
   top: var(--padding-vertical);
   left: var(--padding-horizontal);
   right: calc(var(--bl-size-2xs) + var(--bl-size-m) + var(--bl-size-2xs));
+  max-width: max-content;
   transition: all ease-in 0.2s;
   pointer-events: none;
   font: var(--bl-font-title-3-regular);

--- a/src/components/select/bl-select.css
+++ b/src/components/select/bl-select.css
@@ -9,7 +9,7 @@
 
   --padding-vertical: var(--bl-size-2xs);
   --padding-horizontal: var(--bl-size-xs);
-  --background-color: #fff;
+  --background-color:  var(--bl-color-primary-background);
   --border-color: var(--bl-color-border);
   --border-focus-color: var(--bl-color-primary-hover);
   --icon-color: var(--bl-color-content-tertiary);
@@ -40,6 +40,10 @@
 
 .placeholder {
   color: var(--placeholder-color);
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 :host([disabled]) .placeholder {
@@ -192,16 +196,19 @@ bl-icon {
 
 label {
   position: absolute;
-  display: flex;
-  align-items: center;
+  display: block;
   top: var(--padding-vertical);
   left: var(--padding-horizontal);
+  right: calc(var(--bl-size-2xs) + var(--bl-size-m) + var(--bl-size-2xs));
   transition: all ease-in 0.2s;
   pointer-events: none;
   font: var(--bl-font-title-3-regular);
   font-size: var(--font-size);
   color: var(--placeholder-color);
   padding: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 :where(.select-open, .selected) label {
@@ -213,6 +220,7 @@ label {
   padding: 0 var(--bl-size-3xs);
   background-color: var(--bl-color-primary-background);
   pointer-events: initial;
+  right: var(--padding-horizontal);
 }
 
 :host([label-fixed]) .select-wrapper {
@@ -222,12 +230,13 @@ label {
 :host([label-fixed]) label {
   top: 0;
   left: 0;
+  right: 0;
+  padding: 0;
   transition: none;
   transform: none;
   pointer-events: initial;
   font: var(--bl-font-caption);
   color: var(--label-color);
-  padding: 0;
 }
 
 .help-text,

--- a/src/components/select/bl-select.stories.mdx
+++ b/src/components/select/bl-select.stories.mdx
@@ -82,10 +82,12 @@ export const SelectOptionsSelectedTemplate = (args) => html`<bl-select
 </bl-select>`
 
 # Select
+
 Select component is a component for selecting a value from a list of options.
 Each option should be wrapped with `bl-select-option` component.
 
 ## Basic Usage
+
 <Canvas>
   <Story name="Basic Usage" args={{ placeholder: "Choose country" }} play={selectOpener}>
     {SelectTemplate.bind({})}
@@ -96,6 +98,7 @@ Each option should be wrapped with `bl-select-option` component.
 </Canvas>
 
 ## Multiple Select
+
 There will be checkboxes in select menu when `multiple` attribute is set to true.
 Selected options will be visible on input seperated by commas.
 <Canvas>
@@ -109,9 +112,7 @@ Selected options will be visible on input seperated by commas.
 
 ## Select Labels
 
-Select component optionally can have a `label`.
-If the label is set, it will be a floating label by default.
-If you want to use always it on top of the input, then you can use `label-fixed` attribute.
+Select component optionally can have a `label`. If the label is set, it will be a floating label by default. If you want to use always it on top of the input, then you can use `label-fixed` attribute.
 
 <Canvas isColumn>
   <Story name="Select With Label" args={{ label: "Country" }}>
@@ -121,6 +122,21 @@ If you want to use always it on top of the input, then you can use `label-fixed`
     {SelectTemplate.bind({})}
   </Story>
   <Story name="Select Without Label" args={{ placeholder: "Choose country" }}>
+    {SelectTemplate.bind({})}
+  </Story>
+</Canvas>
+
+Select component will cut-out long labels and placeholders those doesn't width of select, with ellipsis char.
+
+
+<Canvas isColumn>
+  <Story name="Select With Long Label" args={{ label: "Very very long label that doesn't fit select component width" }}>
+    {SelectTemplate.bind({})}
+  </Story>
+  <Story name="Select With Fixed Long Label" args={{ label: "Very very long label that doesn't fit select component width", placeholder:"Choose country", labelFixed: true }}>
+    {SelectTemplate.bind({})}
+  </Story>
+  <Story name="Select Without Label with Long Placeholder" args={{ placeholder: "Very very long placeholder that doesn't fit select component width" }}>
     {SelectTemplate.bind({})}
   </Story>
 </Canvas>


### PR DESCRIPTION
This fixes several visual issues about checkbox and select components that is reported in #353 and #352 

* Checkbox checkmark background color
* Checkbox checkmark deformation with limited space
* Checkbox label with long text and multiple lines
* Select component long placeholder and labels

I tried to add extra stories to our storybook to cover those situations in our visual tests.

Fixes #353 
Fixes #352 