### PR TITLE
ci: semantic-release node 18 requirement fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 16
       - name: Install dependencies
         run: npm ci
-      - name: Create env file with release config 
+      - name: Create env file with release config
         run: |
           touch .env
           echo RELEASE=true >> .env
@@ -32,7 +32,7 @@ jobs:
           name: build-output
           path: dist/
       - name: Publish
-        run: npx semantic-release
+        run: npx semantic-release@19
         env:
           NPM_TOKEN: ${{ secrets.TRENDYOL_JS_NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
2 days ago semantic-release, released [their version v20](https://github.com/semantic-release/semantic-release/releases/tag/v20.0.0) by dropping support from node v16 and this [broke our pipeline](https://github.com/Trendyol/baklava/actions/runs/3872612055/jobs/6601716142).

This is quickly fixing this issue by using v19 of semantic-release in our pipeline.

I created to issues about [Node 18 Support](#361) and [npx commands in our pipelines](#362) to track this issue and create a permanent solution, but for now I'm proposing this quick solution since this problem currently blocks our releases.