### PR TITLE
fix(input): reflection of attributes used in styles

### DIFF
--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -37,7 +37,7 @@ export default class BlInput extends FormControlMixin(LitElement) {
   /**
    * Sets label of the input
    */
-  @property({})
+  @property({ reflect: true })
   label?: string;
 
   /**
@@ -103,7 +103,7 @@ export default class BlInput extends FormControlMixin(LitElement) {
   /**
    * Makes label as fixed positioned
    */
-  @property({ type: Boolean, attribute: 'label-fixed' })
+  @property({ type: Boolean, attribute: 'label-fixed', reflect: true })
   labelFixed = false;
 
   /**


### PR DESCRIPTION
We use `label` and `label-fixed` attributes in styles of component. So they should be reflected.

Fixes #378 