### PR TITLE
test(storybook): iframe url provided for drawer demo

### DIFF
--- a/.storybook/assets/demo-iframe.html
+++ b/.storybook/assets/demo-iframe.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demo Page</title>
+  <style>
+    body {
+      background-color: #CCCCCC;
+      font-family: Arial, Helvetica, sans-serif;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <h1>Demo Page</h1>
+</body>
+</html>

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -31,7 +31,7 @@ module.exports = {
     buildStoriesJson: true,
   },
   framework: '@storybook/web-components',
-  staticDirs: ['../dist'],
+  staticDirs: ['../dist', { from: './assets', to: '/assets' }],
   webpackFinal: configureWebpack,
   managerWebpack: configureWebpack,
 };

--- a/src/components/drawer/bl-drawer.css
+++ b/src/components/drawer/bl-drawer.css
@@ -63,7 +63,7 @@ header h2 {
 }
 
 section {
-  padding: var(--bl-size-xl) var(--bl-size-xl) var(--bl-size-m) var(--bl-size-xl);
+  padding: var(--bl-size-xl);
 }
 
 .content {

--- a/src/components/drawer/bl-drawer.stories.mdx
+++ b/src/components/drawer/bl-drawer.stories.mdx
@@ -112,7 +112,7 @@ A drawer presents context-specific information and/or actions without leaving th
   </Story>
   <Story name="With caption and embedUrl"
          play={(event) => openDialog(event,{id:'drawer-5'})}
-         args={{id:"drawer-5", buttonText:"with caption, embedUrl", caption: "Caption", embedUrl:"some-url"}}>
+         args={{id:"drawer-5", buttonText:"with caption, embedUrl", caption: "Caption", embedUrl:"/assets/demo-iframe.html"}}>
     {StoryTemplate.bind({})}
   </Story>
 </Canvas>


### PR DESCRIPTION
I added an internal demo page for using with Drawer component in storybook. This should prevent having failing snapshot tests on Chromatic because of failing urls.

Fixes #330 