### PR TITLE
fix(select): reflect label-fixed attribute

### DIFF
--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -28,7 +28,7 @@ export default class BlSelect extends LitElement {
   /**
    * Sets the label value
    */
-  @property({})
+  @property({ reflect: true })
   label?: string;
 
   /**

--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -64,7 +64,7 @@ export default class BlSelect extends LitElement {
   /**
    * Makes label as fixed positioned
    */
-  @property({ type: Boolean, attribute: 'label-fixed' })
+  @property({ type: Boolean, attribute: 'label-fixed', reflect: true })
   labelFixed = false;
 
   /**


### PR DESCRIPTION
Fixes, `labelFixed` property is unusable as a React attribute.