### PR TITLE
fix(input): disabled style and small size fixes

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,6 +17,7 @@ const withNoAnimationOnChromaticLayout = makeDecorator({
       ${isChromatic() ?  html`<style>
         .custom-wrapper {
           --bl-drawer-animation-duration: 0;
+          padding: 25px;
         }
       </style>` : html``}
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -31,8 +31,33 @@ const withNoAnimationOnChromaticLayout = makeDecorator({
   }
 });
 
+
+const extraPaddingForChromatic = makeDecorator({
+  name: 'extraPaddingForChromatic',
+  parameterName: 'extraPaddingForChromatic',
+  skipIfNoParametersOrOptions: true,
+  wrapper: (getStory, context) => {
+    const story = getStory(context);
+    const decoratedStory = html`
+      ${isChromatic() ?  html`<style>
+        .chromatic-wrapper {
+          padding: 25px;
+        }
+      </style>` : html``}
+
+      <div class="chromatic-wrapper">
+        ${ story }
+      </div>
+    `;
+
+    // return the modified story
+    return decoratedStory;
+  }
+});
+
 export const decorators = [
-  withNoAnimationOnChromaticLayout
+  withNoAnimationOnChromaticLayout,
+  extraPaddingForChromatic
 ]
 
 export const parameters = {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,7 +17,6 @@ const withNoAnimationOnChromaticLayout = makeDecorator({
       ${isChromatic() ?  html`<style>
         .custom-wrapper {
           --bl-drawer-animation-duration: 0;
-          padding: 25px;
         }
       </style>` : html``}
 

--- a/src/components/icon/bl-icon.css
+++ b/src/components/icon/bl-icon.css
@@ -1,14 +1,19 @@
 :host {
   display: inline-block;
-  position: relative;
+}
+
+:host div {
+  display: flex;
+  align-items: stretch;
   width: 1em;
   height: 1em;
   min-width: 1em;
   min-height: 1em;
+  overflow: hidden;
+  transform: translateZ(0);
 }
 
-:host div,
 :host svg {
-  width: 100%;
-  height: 100%;
+  width: 1em;
+  height: 1em;
 }

--- a/src/components/input/bl-input.css
+++ b/src/components/input/bl-input.css
@@ -2,111 +2,147 @@
   display: inline-block;
   width: 200px;
   position: relative;
+}
 
-  --bl-input-padding-vertical: var(--bl-size-2xs);
-  --bl-input-padding-horizontal: var(--bl-size-xs);
-  --bl-input-border-color: var(--bl-color-border);
-  --bl-input-icon-color: var(--bl-color-content-tertiary);
-  --bl-input-text-color: var(--bl-color-content-primary);
-  --bl-input-height: var(--bl-size-2xl);
+.wrapper {
+  --border-color: var(--bl-color-border);
+  --icon-color: var(--bl-color-content-tertiary);
+  --text-color: var(--bl-color-content-primary);
+  --height: var(--bl-size-2xl);
+  --input-font: var(--bl-font-body-text-2);
+  --line-height: var(--bl-font-body-text-2-line-height);
+  --icon-size: var(--line-height);
+  --padding-vertical: calc((var(--height) - var(--line-height)) / 2);
+  --padding-horizontal: var(--bl-size-xs);
+
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  gap: var(--bl-size-3xs);
+}
+
+.wrapper:focus-within {
+  --border-color: var(--bl-color-primary);
+  --icon-color: var(--bl-color-primary);
+}
+
+.wrapper.dirty.invalid {
+  --border-color: var(--bl-color-danger);
+  --icon-color: var(--bl-color-danger);
+}
+
+:host([size='large']) .wrapper {
+  --height: var(--bl-size-3xl);
+  --padding-vertical: var(--bl-size-xs);
+  --padding-horizontal: var(--bl-size-m);
+}
+
+:host([size='small']) .wrapper {
+  --height: var(--bl-size-xl);
+  --input-font: var(--bl-font-body-text-3);
+  --padding-vertical: var(--bl-size-3xs);
+  --icon-size: var(--bl-font-body-text-3-line-height);
+}
+
+.input-wrapper {
+  display: flex;
+  box-sizing: border-box;
+  gap: var(--padding-vertical);
+  height: var(--height);
+  border: solid 1px var(--border-color);
+  padding: 0 var(--padding-horizontal);
+  border-radius: 4px;
 }
 
 input {
   outline: none;
-  box-sizing: border-box;
-  height: var(--bl-input-height);
-  border: solid 1px var(--bl-input-border-color);
   width: 100%;
-  font: var(--bl-font-title-3-regular);
-  padding: 0 var(--bl-input-padding-horizontal);
+  align-self: stretch;
+  border: none;
+  font: var(--input-font);
+  color: var(--text-color);
+  -webkit-text-fill-color: var(--text-color);
+  background-color: transparent;
+}
+
+label {
+  position: absolute;
+  top: var(--padding-vertical);
+  left: var(--padding-horizontal);
+  transition: all ease-in 0.2s;
+  pointer-events: none;
+  font: var(--input-font);
+  color: var(--bl-color-content-tertiary);
+  padding: 0;
+}
+
+.icon {
+  flex-basis: var(icon-size);
+  align-self: center;
+  height: var(--icon-size);
+}
+
+.wrapper:not(.has-icon) .icon {
+  display: none;
+}
+
+.hint {
+  font: var(--bl-font-body-text-3);
+  padding: 0 var(--padding-horizontal);
+}
+
+.hint p {
+  padding: 0;
   margin: 0;
-  border-radius: 4px;
-  color: var(--bl-input-text-color);
 }
 
 bl-icon {
-  position: absolute;
-  top: var(--bl-input-padding-vertical);
-  right: var(--bl-input-padding-horizontal);
-  font-size: var(--bl-size-m);
-  z-index: 1;
-  color: var(--bl-input-icon-color);
+  font-size: var(--icon-size);
+  color: var(--icon-color);
+  height: var(--icon-size);
 }
 
-input:focus {
-  --bl-input-border-color: var(--bl-color-primary);
-}
-
-:host([label-fixed]) bl-icon {
-  top: calc(var(--bl-input-padding-vertical) + var(--bl-size-m));
-}
-
-input:focus ~ bl-icon {
-  --bl-input-icon-color: var(--bl-color-primary);
-}
-
-:host ::placeholder {
+::placeholder {
   color: var(--bl-color-content-tertiary);
 }
 
 :host([label]) ::placeholder {
   color: transparent;
+  -webkit-text-fill-color: transparent;
   transition: color ease-out 0.4s;
 }
 
-:host input:focus::placeholder,
-:host([label-fixed]) ::placeholder {
+:host([label-fixed]) ::placeholder,
+:host .wrapper:focus-within ::placeholder {
   color: var(--bl-color-content-tertiary);
+}
+
+:host([disabled]) .input-wrapper {
+  cursor: not-allowed;
+  background-color: var(--bl-color-secondary-background);
+
+  --text-color: var(--bl-color-content-passive);
 }
 
 input:disabled {
-  background-color: var(--bl-color-primary-background);
-
-  --bl-input-text-color: var(--bl-color-content-tertiary);
+  cursor: not-allowed;
 }
 
-input.dirty:invalid {
-  --bl-input-border-color: var(--bl-color-danger);
-}
+:where(.wrapper:focus-within, .wrapper.has-value) label {
+  --padding: var(--bl-size-3xs);
 
-input.has-icon {
-  padding-right: calc(var(--bl-size-xs) * 2 + var(--bl-size-m));
-}
-
-.error-icon,
-.invalid-text {
-  display: none;
-}
-
-label {
-  position: absolute;
-  top: var(--bl-input-padding-vertical);
-  left: var(--bl-input-padding-horizontal);
-  transition: all ease-in 0.2s;
-  pointer-events: none;
-  font: var(--bl-font-title-3-regular);
-  color: var(--bl-color-content-tertiary);
-  padding: 0;
-}
-
-:where(input:focus, input.has-value) ~ label {
   top: 0;
-  left: var(--bl-size-2xs);
+  left: calc(var(--padding-horizontal) - var(--padding));
   transform: translateY(-50%);
   font: var(--bl-font-caption);
   color: var(--bl-color-content-secondary);
-  padding: 0 var(--bl-size-3xs);
+  padding: 0 var(--padding);
   background-color: var(--bl-color-primary-background);
   pointer-events: initial;
 }
 
-:host([label-fixed]) {
-  padding-top: var(--bl-size-m);
-}
-
 :host([label-fixed]) label {
-  top: 0;
-  left: 0;
+  position: static;
   transition: none;
   transform: none;
   pointer-events: initial;
@@ -115,18 +151,14 @@ label {
   padding: 0;
 }
 
-.dirty:invalid ~ label {
-  color: var(--bl-color-danger);
-}
-
-.invalid-text,
-.help-text {
-  font: var(--bl-font-title-4-regular);
-  padding: var(--bl-size-3xs) var(--bl-input-padding-horizontal);
-  margin: 0;
-}
-
+.error-icon,
 .invalid-text {
+  display: none;
+}
+
+.dirty.invalid label,
+.invalid-text,
+.error-icon {
   color: var(--bl-color-danger);
 }
 
@@ -134,32 +166,18 @@ label {
   color: var(--bl-color-content-secondary);
 }
 
-.error-icon {
-  color: var(--bl-color-danger);
-}
-
-.dirty:invalid ~ .invalid-text {
+.dirty.invalid .invalid-text {
   display: block;
 }
 
-.dirty:invalid ~ .help-text {
+.dirty.invalid .help-text {
   display: none;
 }
 
-.dirty:invalid ~ .error-icon {
+.dirty.invalid .error-icon {
   display: inline-block;
 }
 
-.dirty:invalid ~ .custom-icon ~ .error-icon {
+.dirty.invalid .custom-icon ~ .error-icon {
   display: none;
-}
-
-.dirty:invalid ~ .custom-icon {
-  --bl-input-icon-color: var(--bl-color-danger);
-}
-
-:host([size='large']) {
-  --bl-input-height: var(--bl-size-3xl);
-  --bl-input-padding-vertical: var(--bl-size-xs);
-  --bl-input-padding-horizontal: var(--bl-size-m);
 }

--- a/src/components/input/bl-input.css
+++ b/src/components/input/bl-input.css
@@ -148,7 +148,7 @@ input:disabled {
   pointer-events: initial;
 }
 
-:where(.wrapper.has-icon:focus-within, .wrapper.has-icon.has-value) label {
+:where(.has-icon:not(:focus-within), .has-icon:not(.has-value)) label {
   right: calc(var(--padding-horizontal) + var(--icon-size) + var(--padding-vertical));
 }
 

--- a/src/components/input/bl-input.css
+++ b/src/components/input/bl-input.css
@@ -147,7 +147,7 @@ input:disabled {
   transform: translateY(-50%);
   font: var(--bl-font-caption);
   color: var(--bl-color-content-secondary);
-  padding: 0 var(--padding);
+  padding: 0 var(--label-padding);
   background-color: var(--bl-color-primary-background);
   pointer-events: initial;
 }

--- a/src/components/input/bl-input.css
+++ b/src/components/input/bl-input.css
@@ -44,27 +44,6 @@
   --icon-size: var(--bl-font-body-text-3-line-height);
 }
 
-.input-wrapper {
-  display: flex;
-  box-sizing: border-box;
-  gap: var(--padding-vertical);
-  height: var(--height);
-  border: solid 1px var(--border-color);
-  padding: 0 var(--padding-horizontal);
-  border-radius: 4px;
-}
-
-input {
-  outline: none;
-  width: 100%;
-  align-self: stretch;
-  border: none;
-  font: var(--input-font);
-  color: var(--text-color);
-  -webkit-text-fill-color: var(--text-color);
-  background-color: transparent;
-}
-
 label {
   position: absolute;
   top: var(--padding-vertical);
@@ -81,8 +60,32 @@ label {
   text-overflow: ellipsis;
 }
 
+.input-wrapper {
+  --border-size: 1px;
+
+  display: flex;
+  box-sizing: border-box;
+  gap: var(--padding-vertical);
+  height: var(--height);
+  border: solid var(--border-size) var(--border-color);
+  padding: 0 calc(var(--padding-horizontal) - var(--border-size));
+  border-radius: 4px;
+}
+
+input {
+  width: 100%;
+  align-self: stretch;
+  outline: 0;
+  border: 0;
+  padding: 0;
+  font: var(--input-font);
+  color: var(--text-color);
+  -webkit-text-fill-color: var(--text-color);
+  background-color: transparent;
+}
+
 .icon {
-  flex-basis: var(icon-size);
+  flex-basis: var(--icon-size);
   align-self: center;
   height: var(--icon-size);
 }
@@ -92,6 +95,7 @@ label {
 }
 
 .hint {
+  display: none;
   font: var(--bl-font-body-text-3);
   padding: 0 var(--padding-horizontal);
 }
@@ -136,10 +140,10 @@ input:disabled {
 }
 
 :where(.wrapper:focus-within, .wrapper.has-value) label {
-  --padding: var(--bl-size-3xs);
+  --label-padding: var(--bl-size-3xs);
 
   top: 0;
-  left: calc(var(--padding-horizontal) - var(--padding));
+  left: calc(var(--padding-horizontal) - var(--label-padding));
   transform: translateY(-50%);
   font: var(--bl-font-caption);
   color: var(--bl-color-content-secondary);
@@ -175,6 +179,11 @@ input:disabled {
 
 .help-text {
   color: var(--bl-color-content-secondary);
+}
+
+:host([help-text]) .hint,
+.dirty.invalid .hint {
+  display: block;
 }
 
 .dirty.invalid .invalid-text {

--- a/src/components/input/bl-input.css
+++ b/src/components/input/bl-input.css
@@ -69,11 +69,16 @@ label {
   position: absolute;
   top: var(--padding-vertical);
   left: var(--padding-horizontal);
+  right: var(--padding-horizontal);
+  max-width: max-content;
   transition: all ease-in 0.2s;
   pointer-events: none;
   font: var(--input-font);
   color: var(--bl-color-content-tertiary);
   padding: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .icon {
@@ -104,6 +109,7 @@ bl-icon {
 
 ::placeholder {
   color: var(--bl-color-content-tertiary);
+  -webkit-text-fill-color: var(--bl-color-content-tertiary);
 }
 
 :host([label]) ::placeholder {
@@ -115,6 +121,7 @@ bl-icon {
 :host([label-fixed]) ::placeholder,
 :host .wrapper:focus-within ::placeholder {
   color: var(--bl-color-content-tertiary);
+  -webkit-text-fill-color: var(--bl-color-content-tertiary);
 }
 
 :host([disabled]) .input-wrapper {
@@ -139,6 +146,10 @@ input:disabled {
   padding: 0 var(--padding);
   background-color: var(--bl-color-primary-background);
   pointer-events: initial;
+}
+
+:where(.wrapper.has-icon:focus-within, .wrapper.has-icon.has-value) label {
+  right: calc(var(--padding-horizontal) + var(--icon-size) + var(--padding-vertical));
 }
 
 :host([label-fixed]) label {

--- a/src/components/input/bl-input.stories.mdx
+++ b/src/components/input/bl-input.stories.mdx
@@ -95,9 +95,9 @@ export const SingleInputTemplate = (args) => html`<bl-input
   ></bl-input>`
 
 export const SizeVariantsTemplate = args => html`
-  ${SingleInputTemplate({ size: 'large', ...args })}
-  ${SingleInputTemplate({ size: 'medium', ...args })}
-  ${SingleInputTemplate({ size: 'small', ...args })}
+${SingleInputTemplate({ size: 'large', ...args })}
+${SingleInputTemplate({ size: 'medium', ...args })}
+${SingleInputTemplate({ size: 'small', ...args })}
 `
 
 # Input
@@ -106,8 +106,6 @@ export const SizeVariantsTemplate = args => html`
 <bl-badge icon="puzzle">[Figma](https://www.figma.com/file/RrcLH0mWpIUy4vwuTlDeKN/Baklava-Design-Guide?node-id=4%3A5586)</bl-badge>
 
 Input component is the component for taking text input from user.
-
-<bl-alert variant="warning" icon>Inline styles in examples are only for **demo purposes**. Use regular CSS classes or tag selectors to set styles.</bl-alert>
 
 ## Basic Usage
 
@@ -144,6 +142,20 @@ If you want to use always it on top of the input, then you can use `label-fixed`
     {SingleInputTemplate.bind({})}
   </Story>
   <Story name="Input with value" args={{ label: 'Your name', placeholder: 'Name Surname', value: 'Random User' }}>
+    {SingleInputTemplate.bind({})}
+  </Story>
+</Canvas>
+
+Input component will cut-out long labels those doesn't width of input, with ellipsis char.
+
+<Canvas isColumn>
+  <Story name="Input With Long Label" args={{ label: "Very very long label that doesn't fit select component width" }}>
+    {SingleInputTemplate.bind({})}
+  </Story>
+  <Story name="Input With Long Label with Icon" args={{ label: "Very very long label that doesn't fit select component width", icon: 'profile' }}>
+    {SingleInputTemplate.bind({})}
+  </Story>
+  <Story name="Input With Fixed Long Label" args={{ label: "Very very long label that doesn't fit select component width", placeholder: "Username", labelFixed: true }}>
     {SingleInputTemplate.bind({})}
   </Story>
 </Canvas>

--- a/src/components/input/bl-input.stories.mdx
+++ b/src/components/input/bl-input.stories.mdx
@@ -59,7 +59,7 @@ import {
     size: {
       control: {
         type: 'select',
-        options: ['medium', 'large']
+        options: ['small', 'medium', 'large']
       },
       type: 'string'
     },

--- a/src/components/input/bl-input.stories.mdx
+++ b/src/components/input/bl-input.stories.mdx
@@ -94,10 +94,10 @@ export const SingleInputTemplate = (args) => html`<bl-input
     size='${ifDefined(args.size)}'
   ></bl-input>`
 
-export const LabelStylesTemplate = args => html`
-  ${SingleInputTemplate({ labelFixed: true, ...args })}
-  ${SingleInputTemplate({ labelFixed: false, ...args })}
-  ${BlButton()}
+export const SizeVariantsTemplate = args => html`
+  ${SingleInputTemplate({ size: 'large', ...args })}
+  ${SingleInputTemplate({ size: 'medium', ...args })}
+  ${SingleInputTemplate({ size: 'small', ...args })}
 `
 
 # Input
@@ -201,11 +201,43 @@ Validation error messages are used from default browser error messages by defaul
 
 ## Input Sizes
 
-Inputs have 2 size options: `medium` and `large`. `medium` size is default and if you want to show a large input you can set `size` attribute to `large`.
+Inputs have 3 size options: `large`, `medium` and `small`. `medium` size is default and if you want to show a large or small input you can set `size` attribute.
 
 <Canvas>
-  <Story name="Large Input"
-         args={{ type: 'text', label: 'User Name', size: 'large' }}
+  <Story name="Input sizes without value"
+         args={{ type: 'text', label: 'User Name', icon: 'profile' }}
+  >
+    {SizeVariantsTemplate.bind({})}
+  </Story>
+  <Story name="Input sizes with value"
+         args={{ type: 'text', label: 'User Name', value: 'excalibur82' }}
+  >
+    {SizeVariantsTemplate.bind({})}
+  </Story>
+</Canvas>
+
+## Disabled Input
+
+Input can be set as disabled by adding `disabled` attribute.
+
+<Canvas isColumn>
+  <Story name="Disabled Input with label"
+         args={{ type: 'text', label: 'User Name', disabled: true }}
+  >
+    {SingleInputTemplate.bind({})}
+  </Story>
+  <Story name="Disabled Input with placeholder"
+         args={{ type: 'text', label: 'User Name', labelFixed: true, placeholder: 'namesurname', disabled: true }}
+  >
+    {SingleInputTemplate.bind({})}
+  </Story>
+  <Story name="Disabled Input with value"
+         args={{ type: 'text', label: 'User Name', value: 'excalibur82', disabled: true }}
+  >
+    {SingleInputTemplate.bind({})}
+  </Story>
+  <Story name="Disabled Input with icon"
+         args={{ type: 'text', label: 'User Name', icon: 'profile', disabled: true }}
   >
     {SingleInputTemplate.bind({})}
   </Story>

--- a/src/components/input/bl-input.stories.mdx
+++ b/src/components/input/bl-input.stories.mdx
@@ -10,6 +10,9 @@ import {
 <Meta
   title="Components/Input"
   component="bl-input"
+  parameters={{
+    extraPaddingForChromatic: true,
+  }}
   argTypes={{
     label: {
       control: 'text',

--- a/src/components/input/bl-input.stories.mdx
+++ b/src/components/input/bl-input.stories.mdx
@@ -66,7 +66,7 @@ import {
     disabled: {
       control: 'boolean',
     },
-    'label-fixed': {
+    labelFixed: {
       control: 'boolean',
     },
     helpText: {

--- a/src/components/input/bl-input.test.ts
+++ b/src/components/input/bl-input.test.ts
@@ -27,6 +27,7 @@ describe('bl-input', () => {
             </bl-icon>
           </div>
         </div>
+        <div class="hint"></div>
       </div>
     `
     );

--- a/src/components/input/bl-input.test.ts
+++ b/src/components/input/bl-input.test.ts
@@ -12,16 +12,24 @@ describe('bl-input', () => {
     assert.shadowDom.equal(
       el,
       `
-      <input
-        aria-invalid="false"
-        id="input"
-        type="text"
-      >
-      <bl-icon
-        class="error-icon"
-        name="alert"
-      >
-      </bl-icon>
+      <div class="wrapper">
+        <div class="input-wrapper">
+          <input
+            aria-invalid="false"
+            id="input"
+            type="text"
+          >
+          <div class="icon">
+            <bl-icon
+              class="error-icon"
+              name="alert"
+            >
+            </bl-icon>
+          </div>
+        </div>
+        <div class="hint">
+        </div>
+      </div>
     `
     );
   });

--- a/src/components/input/bl-input.test.ts
+++ b/src/components/input/bl-input.test.ts
@@ -27,8 +27,6 @@ describe('bl-input', () => {
             </bl-icon>
           </div>
         </div>
-        <div class="hint">
-        </div>
       </div>
     `
     );

--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -204,6 +204,11 @@ export default class BlInput extends FormControlMixin(LitElement) {
       ? html`<p id="errorMessage" aria-live="polite" class="invalid-text">${this.validationMessage}</p>`
       : ``;
     const helpMessage = this.helpText ? html`<p id="helpText" class="help-text">${this.helpText}</p>` : ``;
+    const hintMessage = invalidMessage || helpMessage ? html`<div class="hint">
+      ${invalidMessage}
+      ${helpMessage}
+    </div>` : ``;
+
     const icon = this.icon
       ? html`<bl-icon class="custom-icon" name="${this.icon}"></bl-icon>`
       : '';
@@ -240,10 +245,7 @@ export default class BlInput extends FormControlMixin(LitElement) {
         />
         <div class="icon">${icon}<bl-icon class="error-icon" name="alert"></bl-icon></div>
       </div>
-      <div class="hint">
-        ${invalidMessage}
-        ${helpMessage}
-      </div>
+      ${hintMessage}
     </div>`;
   }
 }

--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -121,7 +121,7 @@ export default class BlInput extends FormControlMixin(LitElement) {
   /**
    * Adds help text
    */
-  @property({ type: String, attribute: 'help-text' })
+  @property({ type: String, attribute: 'help-text', reflect: true })
   helpText?: string;
 
   /**
@@ -204,10 +204,6 @@ export default class BlInput extends FormControlMixin(LitElement) {
       ? html`<p id="errorMessage" aria-live="polite" class="invalid-text">${this.validationMessage}</p>`
       : ``;
     const helpMessage = this.helpText ? html`<p id="helpText" class="help-text">${this.helpText}</p>` : ``;
-    const hintMessage = invalidMessage || helpMessage ? html`<div class="hint">
-      ${invalidMessage}
-      ${helpMessage}
-    </div>` : ``;
 
     const icon = this.icon
       ? html`<bl-icon class="custom-icon" name="${this.icon}"></bl-icon>`
@@ -245,7 +241,10 @@ export default class BlInput extends FormControlMixin(LitElement) {
         />
         <div class="icon">${icon}<bl-icon class="error-icon" name="alert"></bl-icon></div>
       </div>
-      ${hintMessage}
+      <div class="hint">
+        ${invalidMessage}
+        ${helpMessage}
+      </div>
     </div>`;
   }
 }

--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -205,40 +205,46 @@ export default class BlInput extends FormControlMixin(LitElement) {
       : ``;
     const helpMessage = this.helpText ? html`<p id="helpText" class="help-text">${this.helpText}</p>` : ``;
     const icon = this.icon
-      ? html` <bl-icon class="custom-icon" name="${this.icon}"></bl-icon>`
+      ? html`<bl-icon class="custom-icon" name="${this.icon}"></bl-icon>`
       : '';
     const label = this.label ? html`<label for="input">${this.label}</label>` : '';
 
     const classes = {
-      'dirty': this.dirty,
+      wrapper: true,
+      dirty: this.dirty,
+      invalid: !this.checkValidity(),
       'has-icon': this.icon || (this.dirty && !this.checkValidity()),
       'has-value': this.value !== null && this.value !== '',
     };
 
-    return html`
-      <input
-        id="input"
-        type=${this.type}
-        class=${classMap(classes)}
-        .value=${live(this.value)}
-        placeholder="${ifDefined(this.placeholder)}"
-        minlength="${ifDefined(this.minlength)}"
-        maxlength="${ifDefined(this.maxlength)}"
-        min="${ifDefined(this.min)}"
-        max="${ifDefined(this.max)}"
-        step="${ifDefined(this.step)}"
-        ?required=${this.required}
-        ?disabled=${this.disabled}
-        @change=${this.changeHandler}
-        @input=${this.inputHandler}
-        aria-invalid=${this.checkValidity() ? 'false' : 'true'}
-        aria-describedby=${ifDefined(this.helpText ? "helpText" : undefined)}
-        aria-errormessage=${ifDefined(this.checkValidity() ? undefined : "errorMessage")}
-      />
-      ${label} ${icon}
-      <bl-icon class="error-icon" name="alert"></bl-icon>
-      ${invalidMessage} ${helpMessage}
-    `;
+    return html`<div class=${classMap(classes)}>
+      ${label}
+      <div class="input-wrapper">
+        <input
+          id="input"
+          type=${this.type}
+          .value=${live(this.value)}
+          placeholder="${ifDefined(this.placeholder)}"
+          minlength="${ifDefined(this.minlength)}"
+          maxlength="${ifDefined(this.maxlength)}"
+          min="${ifDefined(this.min)}"
+          max="${ifDefined(this.max)}"
+          step="${ifDefined(this.step)}"
+          ?required=${this.required}
+          ?disabled=${this.disabled}
+          @change=${this.changeHandler}
+          @input=${this.inputHandler}
+          aria-invalid=${this.checkValidity() ? 'false' : 'true'}
+          aria-describedby=${ifDefined(this.helpText ? "helpText" : undefined)}
+          aria-errormessage=${ifDefined(this.checkValidity() ? undefined : "errorMessage")}
+        />
+        <div class="icon">${icon}<bl-icon class="error-icon" name="alert"></bl-icon></div>
+      </div>
+      <div class="hint">
+        ${invalidMessage}
+        ${helpMessage}
+      </div>
+    </div>`;
   }
 }
 

--- a/src/themes/default.css
+++ b/src/themes/default.css
@@ -173,7 +173,7 @@
   --bl-font-body-text-3: var(--bl-font-weight-regular) var(--bl-font-body-text-3-size) var(--bl-font-family);
 
   /* Font Style: Caption */
-  --bl-font-caption-font-size: var(--bl-font-size-s);
+  --bl-font-caption-font-size: var(--bl-font-size-xs);
   --bl-font-caption-line-height: calc(var(--bl-font-caption-font-size) + var(--bl-size-4xs));
   --bl-font-caption-size: var(--bl-font-caption-font-size)/var(--bl-font-caption-line-height);
   --bl-font-caption: var(--bl-font-weight-medium) var(--bl-font-caption-size) var(--bl-font-family);


### PR DESCRIPTION
This PR fixes various issues in input component

* Disabled style for input fixed
* Small size added
* Vertical alignments fixed
* Internal component structure refactored for creating extra flexibility for upcoming features (like #388), better reliability and maintainability
* A sizing issue in Safari for icon component fixed
* Handling of long labels those doesn't fit the input
* Caption font-size fixed (it's 10px in design but it was 12px in our default.css)
* Input padding was 1px off comparing to design
* Input padding was wrong on iPad, fixed

Fixes #387
Closes #374 