### PR TITLE
fix(textarea): unneeded padding cleared

### DIFF
--- a/src/components/textarea/bl-textarea.css
+++ b/src/components/textarea/bl-textarea.css
@@ -124,10 +124,6 @@ label {
   pointer-events: initial;
 }
 
-:host([label-fixed]) {
-  padding-top: var(--bl-size-m);
-}
-
 :host ::placeholder,
 :host([label-fixed]) ::placeholder {
   color: var(--bl-color-content-tertiary);


### PR DESCRIPTION
Unneeded top padding in textarea while using with fixed labels cleared.

Fixes #400
