### PR TITLE
feat(input): add loading state

### DIFF
--- a/src/components/button/bl-button.css
+++ b/src/components/button/bl-button.css
@@ -1,3 +1,8 @@
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(359deg); }
+}
+
 :host {
   display: var(--bl-button-display, inline-block);
   max-width: 100%;
@@ -23,7 +28,7 @@
   justify-content: var(--bl-button-justify, center);
   align-items: center;
   box-sizing: border-box;
-  width:100%;
+  width: 100%;
   height: var(--height);
   border: solid 1px var(--border-color);
   border-radius: 6px;
@@ -76,9 +81,13 @@
 .button:focus-visible::after {
   border: 2px solid var(--main-color);
   border-radius: var(--bl-border-radius-l);
-  content: "";
+  content: '';
   position: absolute;
   inset: -4px;
+}
+
+.loading-icon {
+  animation: spin 1s linear infinite;
 }
 
 :host ::slotted(bl-icon) {

--- a/src/components/button/bl-button.test.ts
+++ b/src/components/button/bl-button.test.ts
@@ -86,6 +86,23 @@ describe('bl-button', () => {
 
       expect(el.getAttribute('target')).to.eq('_self');
     });
+
+    it('is disabled button during loading state', async () => {
+      const el = await fixture<typeOfBlButton>(
+        html`<bl-button loading>Test</bl-button>`
+      );
+      const loadingIcon = el.querySelector('.loading-icon');
+      expect(loadingIcon).to.exist;
+      expect(el).to.have.attribute('loading');
+      expect(el).to.have.attribute('disabled');
+
+      el.removeAttribute('loading');
+      await elementUpdated(el);
+
+      expect(loadingIcon).to.not.exist;
+      expect(el).to.not.have.attribute('disabled');
+      expect(el).to.not.have.attribute('loading');
+    });
   });
   describe('Slot', () => {
     it('renders default slot with element', async () => {

--- a/src/components/button/bl-button.ts
+++ b/src/components/button/bl-button.ts
@@ -50,6 +50,12 @@ export default class BlButton extends LitElement {
   @property({ type: String })
   label: string;
 
+   /**
+   * Sets loading state of button
+   */
+   @property({ type: Boolean, reflect: true })
+   loading = false;
+
   /**
    * Sets button as disabled
    */
@@ -151,8 +157,10 @@ export default class BlButton extends LitElement {
   }
 
   render(): TemplateResult {
+    this.disabled = this.loading;
     const isAnchor = !!this.href;
     const icon = this.icon ? html`<bl-icon name=${this.icon}></bl-icon>` : '';
+    const loadingIcon = this.loading ? html`<bl-icon class="loading-icon" name="loading"></bl-icon>` : '';
     const slots = html`<slot name="icon">${icon}</slot> <span class="label"><slot></slot></span>`;
     const caret = this.dropdown ? this.caretTemplate() : '';
     const classes = classMap({
@@ -179,7 +187,7 @@ export default class BlButton extends LitElement {
           ?disabled=${this.disabled}
           @click="${this._handleClick}"
         >
-          ${slots} ${caret}
+         ${loadingIcon} ${slots} ${caret}
         </button>`;
   }
 }

--- a/src/components/button/bl-button.ts
+++ b/src/components/button/bl-button.ts
@@ -53,7 +53,7 @@ export default class BlButton extends LitElement {
    /**
    * Sets loading state of button
    */
-   @property({ type: Boolean, reflect: true })
+   @property({ type: Boolean })
    loading = false;
 
   /**


### PR DESCRIPTION
- Added button loading state
- Connected to disabled state, enables when loading is `true`
- Tests will be added/fixed after PR review

Notes:
- Hesitant about the relation between disabled and loading states handling
- Does loading state requires `reflect` property?

https://user-images.githubusercontent.com/47941171/218412709-69e30806-8b15-4c1f-ace2-b7da229f91d8.mov

