### PR TITLE
fix(react): fix custom element undefined error in electron

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -7,6 +7,7 @@ module.exports = {
       [
         'storybook',
         'design',
+        'react',
         // Components as scopes listed below
         'button',
         'icon',

--- a/scripts/generate-react-exports.js
+++ b/scripts/generate-react-exports.js
@@ -51,12 +51,12 @@ for (const module of customElementsModules) {
 
   baklavaReactFileParts.push(
 `export const ${componentName} = React.lazy<ReactWebComponent<${Type}${eventTypes}>>(() =>
-  customElements.whenDefined('${fileName}').then(elem => ({
+  customElements.whenDefined('${fileName}').then(() => ({
       default: createComponent<${Type}>(
         {
           react: React,
           tagName: '${fileName}',
-          elementClass: elem,
+          elementClass: customElements.get('${fileName}'),
           events: ${JSON.stringify(eventNames)}
         }
       )


### PR DESCRIPTION
@Enes5519 noticed a problem in their Cypress tests inside Electron, that fails while defining React wrappers. We are getting the reference of the custom element with `customElements.whenDefined(elem =>` and pass this `elem` reference to the `createComponent` method of Lit's react component generator. But somehow in Electron, this `elem` becomes `undefined`, but `customElements.get('bl-button')` returns the proper class reference.

While we are still investigating the reason, I just created this PR to be ready to change our approach, since result doesn't change on both ways.