### PR TITLE
test(textarea): fix timeout test

### DIFF
--- a/src/components/textarea/bl-textarea.test.ts
+++ b/src/components/textarea/bl-textarea.test.ts
@@ -79,15 +79,12 @@ describe('bl-textarea', () => {
 
   it('should expand when input text is longer than one row', async () => {
     const el = await fixture<BlTextarea>(
-      html`<bl-textarea value="some dummy text" expand rows="1"></bl-textarea>`
+      html`<bl-textarea
+        value="some dummy text some dummy text some dummy text some dummy text some dummy text some dummy text some dummy text some dummy text"
+        expand
+        rows="1"
+      ></bl-textarea>`
     );
-    const textarea = el.shadowRoot?.querySelector('textarea');
-
-    await textarea?.focus();
-
-    await sendKeys({
-      type: 'some dummy text some dummy text some dummy text some dummy text some dummy text some dummy text some dummy text some dummy text',
-    });
 
     const height = getComputedStyle(el.validationTarget).height;
 
@@ -96,7 +93,8 @@ describe('bl-textarea', () => {
 
   it('should have same heights if they have same max-rows', async () => {
     const longText = 'some dummy text some dummy text some dummy text some dummy text';
-    const longerText = 'some dummy text some dummy text some dummy text some dummy text' +
+    const longerText =
+      'some dummy text some dummy text some dummy text some dummy text' +
       ' some dummy text some dummy text some dummy text some dummy text' +
       'some dummy text some dummy text some dummy text some dummy text';
 


### PR DESCRIPTION
This PR fixes the test in Textarea component which was failing with timeout due to `sendKeys` with a long text.