### PR TITLE
feat: new attributes for form fields

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -70,7 +70,7 @@ const args = parseArgs(process.argv.slice(2), {
       const { host, port } = await ctx.serve(
         {
           servedir,
-          host: '0.0.0.0',
+          host: 'localhost',
         }
       );
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -70,7 +70,7 @@ const args = parseArgs(process.argv.slice(2), {
       const { host, port } = await ctx.serve(
         {
           servedir,
-          host: 'localhost',
+          host: '0.0.0.0',
         }
       );
 

--- a/src/components/button/bl-button.ts
+++ b/src/components/button/bl-button.ts
@@ -99,6 +99,12 @@ export default class BlButton extends LitElement {
   dropdown = false;
 
   /**
+   * Sets button to get keyboard focus automatically
+   */
+  @property({ type: Boolean, reflect: true })
+  autofocus = false;
+
+  /**
    * Active state
    */
   @state({})
@@ -180,6 +186,7 @@ export default class BlButton extends LitElement {
     return isAnchor
       ? html`<a
           class=${classes}
+          ?autofocus=${this.autofocus}
           aria-disabled="${ifDefined(isDisabled)}"
           aria-label="${ifDefined(this.label)}"
           href=${ifDefined(this.href)}
@@ -189,6 +196,7 @@ export default class BlButton extends LitElement {
         </a>`
       : html`<button
           class=${classes}
+          ?autofocus=${this.autofocus}
           aria-disabled="${ifDefined(isDisabled)}"
           aria-label="${ifDefined(this.label)}"
           ?disabled=${isDisabled}

--- a/src/components/dialog/bl-dialog.css
+++ b/src/components/dialog/bl-dialog.css
@@ -1,7 +1,9 @@
 .container {
+  --background-color: var(--bl-color-primary-background);
+
   display: flex;
   flex-direction: column;
-  background: var(--bl-color-primary-background);
+  background: var(--background-color);
   max-width: calc(100vw - var(--bl-size-4xl));
   max-height: calc(100vh - var(--bl-size-4xl));
   min-width: 424px;
@@ -21,9 +23,9 @@
   position: fixed;
 
   /* FIXME: Use z-index variable */
-  z-index: 999; 
+  z-index: 999;
  }
- 
+
 .dialog::backdrop {
   background: #273142;
   opacity: 0.7;
@@ -41,11 +43,11 @@
 
   /* FIXME: Use css variables for alpha colors */
   background: #273142b3;
-  
+
   /* FIXME: Use z-index variable */
-  z-index: 999; 
+  z-index: 999;
  }
- 
+
  :host([open]) .dialog-polyfill {
   display: flex;
 }

--- a/src/components/dialog/bl-dialog.stories.mdx
+++ b/src/components/dialog/bl-dialog.stories.mdx
@@ -8,6 +8,10 @@ import { userEvent } from '@storybook/testing-library';
 <Meta
   title="Components/Dialog"
   component="bl-dialog"
+  parameters={{
+    layout: 'fullscreen',
+    chromatic: { viewports: [1000] },
+  }}
   argTypes={{
     open: {
       control: "boolean",

--- a/src/components/dialog/bl-dialog.stories.mdx
+++ b/src/components/dialog/bl-dialog.stories.mdx
@@ -19,43 +19,27 @@ import { userEvent } from '@storybook/testing-library';
   }}
 />
 
-export const dialogOpener = async (event,dialogClass) => {
-  const target= event.target;
-  const isCanvas = !event.target || target.parentNode.parentNode.getAttribute("id") === "root";
-  let selector=`#docs-root .${dialogClass}`;
-  if(isCanvas){
-    selector = `#root .${dialogClass}`;
-  }
-  const dialog = document.querySelector(selector);
-  dialog.setAttribute("open",true);
-}
-
-export const closeAllDialog = async () => {
-  const dialog = document.querySelector(`#root bl-dialog[open]`);
-  dialog?.removeAttribute("open");
+export const dialogOpener = async (event, dialogId) => {
+  const dialog = document.getElementById(dialogId);
+  dialog.open = true;
 }
 
 export const BasicTemplate = (args) => html`
-<bl-button @click="${(event) => dialogOpener(event,"basic-dialog")}" variant="secondary">Open Dialog</bl-button>
-<bl-dialog class="basic-dialog"
-caption="${ifDefined(args.caption)}"
-open="${ifDefined(args.open)}"
-style = "font: var(--bl-font-body-text-2)">
-  Let us help determine location. This means sending anonymous location data to us.
-  <bl-button slot="primary-action" variant="primary" size="large">Agree</bl-button>
-  <bl-button slot="secondary-action" variant="secondary" kind="danger" size="large">Disagree</bl-button>
-  <bl-button slot="tertiary-action" variant="tertiary" kind="neutral" size="large">Cancel</bl-button>
+<bl-button @click="${(event) => dialogOpener(event, args.id)}" variant="secondary">Open Dialog</bl-button>
+<bl-dialog
+  id=${args.id}
+  caption="${ifDefined(args.caption)}"
+  open="${ifDefined(args.open)}"
+  style = "font: var(--bl-font-body-text-2)">
+  ${ unsafeHTML(args.content) }
+  ${ args.primaryAction ? html`<bl-button slot="primary-action" variant="primary" ?autofocus=${args.focusPrimary} size="large">${args.primaryAction}</bl-button>` : ''}
+  ${ args.secondaryAction ? html`<bl-button slot="secondary-action" variant="secondary" ?autofocus=${args.focusSecondary} size="large">${args.secondaryAction}</bl-button>` : ''}
+  ${ args.tertiaryAction ? html`<bl-button slot="tertiary-action" variant="tertiary" ?autofocus=${args.focusTertiary} size="large">${args.tertiaryAction}</bl-button>` : ''}
 </bl-dialog>
-<script>${closeAllDialog()}</script>
 `
 
 export const TemplateWithStickyFooter = (args) => html`
-<bl-button @click="${(event) => dialogOpener(event,"dialog-with-sticky-footer")}" variant="secondary" kind="success">Open Dialog</bl-button>
-<bl-dialog class="dialog-with-sticky-footer"
-caption="${ifDefined(args.caption)}"
-open="${ifDefined(args.open)}"
-style = "font: var(--bl-font-body-text-2)">
-  <bl-alert icon>Please read all terms and conditions.</bl-alert>
+${BasicTemplate({...args, content: `<bl-alert icon>Please read all terms and conditions.</bl-alert>
   <h4>Lorem ipsum dolor sit amet</h4>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt <br/> ut labore et dolore magna aliqua.
    Ut enim ad minim veniam, quis nostrud exercitation <br/>ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
@@ -101,19 +85,11 @@ style = "font: var(--bl-font-body-text-2)">
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt <br/> ut labore et dolore magna aliqua.
   Ut enim ad minim veniam, quis nostrud exercitation <br/>ullamco laboris nisi ut aliquip ex ea commodo consequat.<br/>
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt <br/> ut labore et dolore magna aliqua.
-  Ut enim ad minim veniam, quis nostrud exercitation <br/>ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-  <bl-button slot="primary-action" kind='success' variant="primary" size="large">Got It</bl-button>
-  <bl-button slot="secondary-action" variant="secondary" kind="neutral" size="large">Cancel</bl-button>
-</bl-dialog>
+  Ut enim ad minim veniam, quis nostrud exercitation <br/>ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>` })}
 `
 
 export const SizingTemplate = (args) => html`
-<bl-button @click="${(event) => dialogOpener(event,"dialog-sizing")}" variant="tertiary" kind="neutral">Open Dialog</bl-button>
-<bl-dialog class="dialog-sizing"
-caption="${ifDefined(args.caption)}"
-open="${ifDefined(args.open)}"
-style = "font: var(--bl-font-body-text-2)">
-  <p style="width:400px; height:200px; margin:0; padding:0">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,
+${BasicTemplate({...args, content: `<p style="width:400px; height:200px; margin:0; padding:0">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,
   when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting,
   remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing
   software like Aldus PageMaker including versions of Lorem Ipsum. Let us help determine location. This means sending anonymous location data to us.
@@ -122,11 +98,7 @@ style = "font: var(--bl-font-body-text-2)">
   of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum"
   (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum,
   "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.
-  </p>
-  <bl-button slot="primary-action" variant="primary" size="large">Agree</bl-button>
-  <bl-button slot="secondary-action" variant="secondary" kind="danger" size="large">Disagree</bl-button>
-  <bl-button slot="tertiary-action" variant="tertiary" kind="neutral" size="large">Cancel</bl-button>
-</bl-dialog>
+  </p>` })}
 `
 
 # Dialog
@@ -152,8 +124,15 @@ To maintain usability level of dialog component:
 ## Basic Usage
 
 <Canvas>
-  <Story name="Basic Usage" play={(event) => dialogOpener(event,"basic-dialog")}
-   args={{ caption: "Use location service?"}}>
+  <Story name="Basic Usage" play={(event) => dialogOpener(event, "basic-dialog")}
+   args={{
+    id: 'basic-dialog',
+    caption: "Use location service?",
+    content: 'Let us help determine location. This means sending anonymous location data to us.',
+    primaryAction: 'Agree',
+    secondaryAction: 'Disagree',
+    tertiaryAction: 'Cancel'
+  }}>
     {BasicTemplate.bind({})}
   </Story>
 </Canvas>
@@ -164,7 +143,12 @@ For long content that does not fit on the page, the dialog action area remains s
 
 <Canvas>
   <Story name="Dialog With Sticky Footer" play={(event) => dialogOpener(event,"dialog-with-sticky-footer")}
-   args={{ caption: "Terms And Conditions"}}>
+   args={{
+    id: 'dialog-with-sticky-footer',
+    caption: "Terms And Conditions",
+    primaryAction: 'Agree',
+    secondaryAction: 'Disagree',
+  }}>
     {TemplateWithStickyFooter.bind({})}
   </Story>
 </Canvas>
@@ -174,10 +158,52 @@ For long content that does not fit on the page, the dialog action area remains s
 The dialog doesn't have any size, it will be fluidly sized regarding its content. You can give your own width and height style to your content.
 
 <Canvas>
-  <Story name="Dialog Sizing" play={(event) => dialogOpener(event,"dialog-sizing")}>
+  <Story name="Dialog Sizing" play={(event) => dialogOpener(event,"dialog-sizing")} args={{
+    id: 'dialog-sizing',
+    primaryAction: 'Agree',
+    secondaryAction: 'Disagree',
+    tertiaryAction: 'Cancel'
+  }}>
     {SizingTemplate.bind({})}
   </Story>
 </Canvas>
+
+## Autofocusing elements in Dialog
+
+By default, when you open a dialog, "close" button get focus automatically. But you can also auto focus on a dialog action this by using
+`autofocus` attribute of the `bl-button`.
+
+<Canvas>
+  <Story name="Dialog with focused action" play={(event) => dialogOpener(event, "dialog-with-focused-action")}
+   args={{
+    id: 'dialog-with-focused-action',
+    caption: "Use location service?",
+    content: 'Let us help determine location. This means sending anonymous location data to us.',
+    primaryAction: 'Agree',
+    secondaryAction: 'Disagree',
+    focusSecondary: true,
+    tertiaryAction: 'Cancel'
+  }}>
+    {BasicTemplate.bind({})}
+  </Story>
+</Canvas>
+
+You may also consider to autofocus user to an input inside the dialog.
+
+
+<Canvas>
+  <Story name="Dialog with focused input" play={(event) => dialogOpener(event, "dialog-with-focused-input")}
+   args={{
+    id: 'dialog-with-focused-input',
+    caption: 'Name your file',
+    content: '<p>Please provide a name for your file</p><bl-input placeholder="filename.pdf" autofocus></bl-input>',
+    primaryAction: 'OK',
+    tertiaryAction: 'Cancel'
+  }}>
+    {BasicTemplate.bind({})}
+  </Story>
+</Canvas>
+
 
 ## Reference
 

--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -4,16 +4,16 @@ import { event, EventDispatcher } from '../../utilities/event';
 import '../button/bl-button';
 import style from './bl-dialog.css';
 
-/**
- * @tag bl-dialog
- * @summary Baklava Dialog component
- */
-
 type DialogElement = {
   showModal: () => void;
   close: () => void;
 };
 
+
+/**
+ * @tag bl-dialog
+ * @summary Baklava Dialog component
+ */
 @customElement('bl-dialog')
 export default class BlDialog extends LitElement {
   static get styles(): CSSResultGroup {

--- a/src/components/input/bl-input.test.ts
+++ b/src/components/input/bl-input.test.ts
@@ -11,8 +11,7 @@ describe('bl-input', () => {
     const el = await fixture<BlInput>(html`<bl-input></bl-input>`);
     assert.shadowDom.equal(
       el,
-      `
-      <div class="wrapper">
+      `<div class="wrapper">
         <div class="input-wrapper">
           <input
             aria-invalid="false"
@@ -28,8 +27,8 @@ describe('bl-input', () => {
           </div>
         </div>
         <div class="hint"></div>
-      </div>
-    `
+      </div>`,
+      { ignoreAttributes: ['for', 'id'] }
     );
   });
 
@@ -199,7 +198,7 @@ describe('bl-input', () => {
 
       form.addEventListener('submit', e => e.preventDefault());
 
-      form.dispatchEvent(new SubmitEvent('submit', {cancelable: true}));
+      form.dispatchEvent(new SubmitEvent('submit', { cancelable: true }));
 
       await elementUpdated(form);
 
@@ -233,7 +232,7 @@ describe('bl-input', () => {
 
       const enterEvent = new KeyboardEvent('keydown', {
         code: 'Enter',
-        cancelable: true
+        cancelable: true,
       });
 
       blInput?.dispatchEvent(enterEvent);

--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -32,14 +32,14 @@ export default class BlInput extends FormControlMixin(LitElement) {
   /**
    * Sets name of the input
    */
-  @property({})
+  @property({ reflect: true })
   name?: string;
 
   /**
    * Type of the input. It's used to set `type` attribute of native input inside. Only `text`, `number` and `password` is supported for now.
    */
-  @property({})
-  type: 'text' | 'password' | 'number' = 'text';
+  @property({ reflect: true })
+  type: 'text' | 'password' | 'number' | 'tel' | 'url' = 'text';
 
   /**
    * Sets label of the input
@@ -50,55 +50,85 @@ export default class BlInput extends FormControlMixin(LitElement) {
   /**
    * Sets placeholder of the input
    */
-  @property({})
+  @property({ reflect: true })
   placeholder?: string;
 
   /**
    * Sets initial value of the input
    */
-  @property()
+  @property({ reflect: true })
   value = '';
 
   /**
    * Makes input a mandatory field
    */
-  @property({ type: Boolean })
+  @property({ type: Boolean, reflect: true })
   required = false;
 
   /**
    * Sets minimum length of the input
    */
-  @property({ type: Number })
+  @property({ type: Number, reflect: true })
   minlength?: number;
 
   /**
    * Sets maximum length of the input
    */
-  @property({ type: Number })
+  @property({ type: Number, reflect: true })
   maxlength?: number;
 
   /**
    * Sets the smallest number can be entered to a `number` input
    */
-  @property({ type: Number })
+  @property({ type: Number, reflect: true })
   min?: number;
 
   /**
    * Sets the biggest number can be entered to a `number` input
    */
-  @property({ type: Number })
+  @property({ type: Number, reflect: true })
   max?: number;
+
+  /**
+   * Sets a regex pattern form the input validation
+   */
+  @property({ type: String, reflect: true })
+  pattern?: string;
 
   /**
    * Sets the increase and decrease step to a `number` input
    */
-  @property({ type: Number })
+  @property({ type: Number, reflect: true })
   step?: number;
+
+  /**
+   * Hints browser to autocomplete this field.
+   */
+  @property({ type: String, reflect: true })
+  autocomplete: string;
+
+  /**
+   * Sets the input mode of the field for asking browser to show the desired keyboard.
+   */
+  @property({ type: String, reflect: true })
+  inputmode: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
+
+  /**
+   * Sets input to get keyboard focus automatically
+   */
+  @property({ type: Boolean, reflect: true })
+  autofocus = false;
+
+  /**
+   * Sets input as read-only field
+   */
+  @property({ type: Boolean, reflect: true })
+  readonly = false;
 
   /**
    * Sets the custom icon name. `bl-icon` component is used to show an icon
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   icon?: string;
 
   /**
@@ -122,7 +152,7 @@ export default class BlInput extends FormControlMixin(LitElement) {
   /**
    * Set custom error message
    */
-  @property({ type: String, attribute: 'invalid-text' })
+  @property({ type: String, attribute: 'invalid-text', reflect: true })
   customInvalidText?: string;
 
   /**
@@ -221,6 +251,8 @@ export default class BlInput extends FormControlMixin(LitElement) {
     }
   }
 
+  private inputId = Math.random().toString(36).substring(2);
+
   render(): TemplateResult {
     const invalidMessage = !this.checkValidity()
       ? html`<p id="errorMessage" aria-live="polite" class="invalid-text">
@@ -232,7 +264,7 @@ export default class BlInput extends FormControlMixin(LitElement) {
       : ``;
 
     const icon = this.icon ? html`<bl-icon class="custom-icon" name="${this.icon}"></bl-icon>` : '';
-    const label = this.label ? html`<label for="input">${this.label}</label>` : '';
+    const label = this.label ? html`<label for=${this.inputId}>${this.label}</label>` : '';
 
     const revealButton = this.passwordInput
       ? html`<bl-button
@@ -266,14 +298,19 @@ export default class BlInput extends FormControlMixin(LitElement) {
       ${label}
       <div class="input-wrapper">
         <input
-          id="input"
+          id=${this.inputId}
           type=${inputType}
           .value=${live(this.value)}
+          inputmode="${ifDefined(this.inputmode)}"
+          ?autofocus=${this.autofocus}
+          ?readonly=${this.readonly}
+          autocomplete="${ifDefined(this.autocomplete)}"
           placeholder="${ifDefined(this.placeholder)}"
           minlength="${ifDefined(this.minlength)}"
           maxlength="${ifDefined(this.maxlength)}"
           min="${ifDefined(this.min)}"
           max="${ifDefined(this.max)}"
+          pattern="${ifDefined(this.pattern)}"
           step="${ifDefined(this.step)}"
           ?required=${this.required}
           ?disabled=${this.disabled}

--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -120,12 +120,6 @@ export default class BlInput extends FormControlMixin(LitElement) {
   autofocus = false;
 
   /**
-   * Sets input as read-only field
-   */
-  @property({ type: Boolean, reflect: true })
-  readonly = false;
-
-  /**
    * Sets the custom icon name. `bl-icon` component is used to show an icon
    */
   @property({ type: String, reflect: true })
@@ -303,7 +297,6 @@ export default class BlInput extends FormControlMixin(LitElement) {
           .value=${live(this.value)}
           inputmode="${ifDefined(this.inputmode)}"
           ?autofocus=${this.autofocus}
-          ?readonly=${this.readonly}
           autocomplete="${ifDefined(this.autocomplete)}"
           placeholder="${ifDefined(this.placeholder)}"
           minlength="${ifDefined(this.minlength)}"

--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -111,6 +111,12 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
   multiple = false;
 
   /**
+   * Sets input to get keyboard focus automatically
+   */
+  @property({ type: Boolean, reflect: true })
+  autofocus = false;
+
+  /**
    * Makes label as fixed positioned
    */
   @property({ type: Boolean, attribute: 'label-fixed', reflect: true })
@@ -295,6 +301,7 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
         'has-overflowed-options': this._additionalSelectedOptionCount > 0
       })}
       tabindex="${this.disabled ? '-1' : 0}"
+      ?autofocus=${this.autofocus}
       @click=${this.togglePopover}
     >
       <span class="placeholder">${this.placeholder}</span>

--- a/src/components/textarea/bl-textarea.css
+++ b/src/components/textarea/bl-textarea.css
@@ -16,6 +16,7 @@
   --height: max(var(--scroll-height), var(--default-scroll-height));
   --input-font: var(--bl-font-body-text-2);
   --border-radius: var(--bl-size-3xs);
+  --border-color: var(--bl-color-border);
 
   display: flex;
   flex-direction: column;
@@ -24,7 +25,7 @@
 }
 
 .input-wrapper {
-  border: solid var(--border-size) var(--bl-color-border);
+  border: solid var(--border-size) var(--border-color);
   border-radius: var(--border-radius);
   padding-top: var(--padding-vertical);
   display: flex;
@@ -82,12 +83,12 @@ textarea:disabled {
 }
 
 .wrapper:focus-within {
-  border-color: var(--bl-color-primary);
+  --border-color: var(--bl-color-primary);
 }
 
 .dirty.max-len-invalid,
 .dirty.invalid {
-  border-color: var(--bl-color-danger);
+  --border-color: var(--bl-color-danger);
 }
 
 :host([label]) ::placeholder {
@@ -168,6 +169,10 @@ label {
 }
 
 :where(.max-len-invalid, .dirty.invalid) .hint > .counter-text {
+  color: var(--bl-color-danger);
+}
+
+.dirty.invalid label {
   color: var(--bl-color-danger);
 }
 

--- a/src/components/textarea/bl-textarea.test.ts
+++ b/src/components/textarea/bl-textarea.test.ts
@@ -20,12 +20,14 @@ describe('bl-textarea', () => {
             id="input"
             name=""
             rows="4"
+            spellcheck="false"
             >
             </textarea>
           </div>
           <div class="hint"></div>
         </div>
-      `
+      `,
+      { ignoreAttributes: ['for', 'id'] }
     );
   });
 

--- a/src/components/textarea/bl-textarea.ts
+++ b/src/components/textarea/bl-textarea.ts
@@ -29,13 +29,13 @@ export default class BlTextarea extends FormControlMixin(LitElement) {
   /**
    * Name of textarea
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   name = '';
 
   /**
    * Makes textarea a mandatory field
    */
-  @property({ type: Boolean })
+  @property({ type: Boolean, reflect: true })
   required = false;
 
   /**
@@ -77,50 +77,80 @@ export default class BlTextarea extends FormControlMixin(LitElement) {
   /**
    * Sets placeholder of the textarea
    */
-  @property({})
+  @property({ reflect: true })
   placeholder?: string;
 
   /**
    * Enables showing character counter.
    */
-  @property({ type: Boolean, attribute: 'character-counter' })
+  @property({ type: Boolean, attribute: 'character-counter', reflect: true })
   characterCounter = false;
 
   /**
    * Adds help text
    */
-  @property({ type: String, attribute: 'help-text' })
+  @property({ type: String, attribute: 'help-text', reflect: true })
   helpText?: string;
 
   /**
    * Set custom error message
    */
-  @property({ type: String, attribute: 'invalid-text' })
+  @property({ type: String, attribute: 'invalid-text', reflect: true })
   customInvalidText?: string;
 
   /**
    * Sets minimum length of the textarea
    */
-  @property({ type: Number })
+  @property({ type: Number, reflect: true })
   minlength?: number;
 
   /**
    * Sets max length of textarea
    */
-  @property({ type: Number })
+  @property({ type: Number, reflect: true })
   maxlength?: number;
 
   /**
    * Sets initial value of the textarea
    */
-  @property()
+  @property({ reflect: true })
   value = '';
 
   /**
    * Sets textarea visible row count.
    */
-  @property({ type: Number })
+  @property({ type: Number, reflect: true })
   rows?: number = 4;
+
+  /**
+   * Sets the input mode of the field for asking browser to show the desired keyboard.
+   */
+  @property({ type: String, reflect: true })
+  inputmode: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
+
+  /**
+   * Sets input to get keyboard focus automatically
+   */
+  @property({ type: Boolean, reflect: true })
+  autofocus = false;
+
+  /**
+   * Sets input as read-only field
+   */
+  @property({ type: Boolean, reflect: true })
+  readonly = false;
+
+  /**
+   * Hints browser to autocomplete this field.
+   */
+  @property({ type: String, reflect: true })
+  autocomplete: string;
+
+  /**
+   * Enables/disables spellcheck feature inside the textarea
+   */
+  @property({ type: String, reflect: true, attribute: 'spellcheck' })
+  spellchecker: 'true' | 'false' = 'false';
 
   @event('bl-input') private onInput: EventDispatcher<string>;
 
@@ -130,6 +160,8 @@ export default class BlTextarea extends FormControlMixin(LitElement) {
 
   @state()
   private customScrollHeight: string | null = null;
+
+  private inputId = Math.random().toString(36).substring(2);
 
   connectedCallback() {
     super.connectedCallback();
@@ -211,7 +243,7 @@ export default class BlTextarea extends FormControlMixin(LitElement) {
     const helpMessage =
       this.helpText ? html`<p class="help-text">${this.helpText}</p>` : ``;
 
-    const label = this.label ? html`<label for="input">${this.label}</label>` : '';
+    const label = this.label ? html`<label for="${this.inputId}">${this.label}</label>` : '';
     const characterCounterText =
       this.characterCounter && this.maxlength
         ? `${this.value.length}/${this.maxlength}`
@@ -241,14 +273,19 @@ export default class BlTextarea extends FormControlMixin(LitElement) {
         ${label}
         <div class="input-wrapper">
           <textarea
-            id="input"
+            id="${this.inputId}"
             name="${ifDefined(this.name)}"
             .value=${live(this.value)}
+            ?autofocus=${this.autofocus}
+            ?readonly=${this.readonly}
+            autocomplete="${ifDefined(this.autocomplete)}"
+            inputmode="${ifDefined(this.inputmode)}"
             placeholder="${ifDefined(this.placeholder)}"
             minlength="${ifDefined(this.minlength)}"
             rows="${ifDefined(this.rows)}"
             ?required=${this.required}
             ?disabled=${this.disabled}
+            spellcheck="${this.spellchecker}"
             @change=${this.changeHandler}
             @input=${this.inputHandler}
             @invalid=${this.onError}

--- a/src/components/textarea/bl-textarea.ts
+++ b/src/components/textarea/bl-textarea.ts
@@ -135,12 +135,6 @@ export default class BlTextarea extends FormControlMixin(LitElement) {
   autofocus = false;
 
   /**
-   * Sets input as read-only field
-   */
-  @property({ type: Boolean, reflect: true })
-  readonly = false;
-
-  /**
    * Hints browser to autocomplete this field.
    */
   @property({ type: String, reflect: true })
@@ -277,7 +271,6 @@ export default class BlTextarea extends FormControlMixin(LitElement) {
             name="${ifDefined(this.name)}"
             .value=${live(this.value)}
             ?autofocus=${this.autofocus}
-            ?readonly=${this.readonly}
             autocomplete="${ifDefined(this.autocomplete)}"
             inputmode="${ifDefined(this.inputmode)}"
             placeholder="${ifDefined(this.placeholder)}"

--- a/src/utilities/form-control.ts
+++ b/src/utilities/form-control.ts
@@ -8,6 +8,7 @@ const validityStates: Array<keyof ValidityState> = [
   'tooShort',
   'rangeUnderflow',
   'rangeOverflow',
+  'stepMismatch',
   'badInput',
   'customError',
 ];


### PR DESCRIPTION
This PR adds missing attributes defined in #405. (currently only for Input and Textarea)

Also added `autofocus` to `bl-button` to allow fixing #406 

Some remarks:

* `autofocus` doesn't work on non-native form elements on Firefox and Safari ([Source](https://caniuse.com/?search=autofocus)). So autofocus doesn't work on select component on those browsers. 
* `autocomplete` doesn't work on Select component. It needs a native form element.

Fixes #474 
Fixes #451 
Closes #406 by adding some examples in Dialog storybook document
