### PR TITLE
fix(popover): using min-width for fit-size

### DIFF
--- a/src/components/dropdown/bl-dropdown.css
+++ b/src/components/dropdown/bl-dropdown.css
@@ -3,42 +3,14 @@
   display: inline-block;
 }
 
-.popover {
-  --left: 0;
-  --top: 0;
-  --border-color: var(--bl-color-primary);
-
-  position: fixed;
-  z-index: var(--bl-index-popover);
-  display: none;
-  flex-direction: column;
-  align-items: flex-start;
-  padding: var(--bl-size-m);
-  gap: var(--bl-size-xs);
-  overflow-y: auto;
-  background: var(--bl-color-primary-background);
-  border: 1px solid var(--border-color);
-
-  /* FIXME: Use variables */
-  box-shadow: 0 10px 15px -8px #27314226;
-  border-radius: var(--bl-size-3xs);
-  left: var(--left);
-  top: var(--top);
-  box-sizing: border-box;
+:host([kind='neutral']) bl-popover {
+  --bl-popover-border-color: var(--bl-color-secondary);
 }
 
-:host([kind='neutral']) .popover {
-  --border-color: var(--bl-color-secondary);
+:host([kind='success']) bl-popover {
+  --bl-popover-border-color: var(--bl-color-success);
 }
 
-:host([kind='success']) .popover {
-  --border-color: var(--bl-color-success);
-}
-
-:host([kind='danger']) .popover {
-  --border-color: var(--bl-color-danger);
-}
-
-.visible {
-  display: flex;
+:host([kind='danger']) bl-popover {
+  --bl-popover-border-color: var(--bl-color-danger);
 }

--- a/src/components/dropdown/bl-dropdown.test.ts
+++ b/src/components/dropdown/bl-dropdown.test.ts
@@ -35,7 +35,7 @@ describe('bl-dropdown', () => {
       >
         Dropdown Button
       </bl-button>
-      <bl-popover placement="bottom-start"><slot></slot></bl-popover>
+      <bl-popover placement="bottom-start" fit-size><slot></slot></bl-popover>
     `
     );
   });

--- a/src/components/dropdown/bl-dropdown.test.ts
+++ b/src/components/dropdown/bl-dropdown.test.ts
@@ -12,6 +12,8 @@ import { sendKeys } from '@web/test-runner-commands';
 
 import type typeOfBlDropdown from './bl-dropdown';
 import BlButton from '../button/bl-button';
+import '../popover/bl-popover';
+import BlPopover from '../popover/bl-popover';
 
 describe('bl-dropdown', () => {
   it('is defined', () => {
@@ -33,7 +35,7 @@ describe('bl-dropdown', () => {
       >
         Dropdown Button
       </bl-button>
-      <div class="popover" aria-expanded="false" role="menu"><slot></slot></div>
+      <bl-popover placement="bottom-start"><slot></slot></bl-popover>
     `
     );
   });
@@ -43,10 +45,12 @@ describe('bl-dropdown', () => {
 
     const buttonHost = <BlButton>el.shadowRoot?.querySelector('bl-button');
     const button = buttonHost.shadowRoot?.querySelector('.button') as HTMLElement | null;
+    const popover = <BlPopover>el.shadowRoot?.querySelector('bl-popover');
 
     button?.click();
 
     expect(el.opened).to.true;
+    expect(popover.visible).to.true;
   });
 
   it('should close dropdown', async () => {
@@ -54,12 +58,15 @@ describe('bl-dropdown', () => {
 
     const buttonHost = <BlButton>el.shadowRoot?.querySelector('bl-button');
     const button = buttonHost.shadowRoot?.querySelector('.button') as HTMLElement | null;
+    const popover = <BlPopover>el.shadowRoot?.querySelector('bl-popover');
 
     button?.click();
     expect(el.opened).to.true;
+    expect(popover.visible).to.true;
 
     button?.click();
     expect(el.opened).to.false;
+    expect(popover.visible).to.false;
   });
 
   it('should close dropdown when click outside', async () => {
@@ -69,15 +76,18 @@ describe('bl-dropdown', () => {
 
     const buttonHost = <BlButton>el.shadowRoot?.querySelector('bl-button');
     const button = buttonHost.shadowRoot?.querySelector('.button') as HTMLElement | null;
+    const popover = <BlPopover>el.shadowRoot?.querySelector('bl-popover');
 
     button?.click();
     expect(el.opened).to.true;
+    expect(popover.visible).to.true;
 
     const body = <HTMLBodyElement>el.closest('body');
     body.click();
 
     setTimeout(() => {
       expect(el.opened).to.false;
+      expect(popover.visible).to.false;
     });
   });
 
@@ -111,6 +121,20 @@ describe('bl-dropdown', () => {
     expect(el).to.exist;
     expect(event).to.exist;
     expect(event.detail).to.be.equal('Dropdown closed!');
+  });
+
+  it('should not change opened property when disabled', async () => {
+    const el = await fixture<typeOfBlDropdown>(html`<bl-dropdown disabled></bl-dropdown>`);
+    expect(el.opened).to.false;
+
+    const buttonHost = <BlButton>el.shadowRoot?.querySelector('bl-button');
+    const button = buttonHost.shadowRoot?.querySelector('.button') as HTMLElement | null;
+    const popover = <BlPopover>el.shadowRoot?.querySelector('bl-popover');
+
+    button?.click();
+
+    expect(el.opened).to.false;
+    expect(popover.visible).to.false;
   });
 
   describe('keyboard navigation', () => {

--- a/src/components/dropdown/bl-dropdown.ts
+++ b/src/components/dropdown/bl-dropdown.ts
@@ -1,15 +1,6 @@
 import { LitElement, html, CSSResultGroup, TemplateResult } from 'lit';
 import { customElement, property, state, query } from 'lit/decorators.js';
-import {
-  computePosition,
-  flip,
-  offset,
-  autoUpdate,
-  size,
-  MiddlewareArguments,
-} from '@floating-ui/dom';
 import { event, EventDispatcher } from '../../utilities/event';
-import { classMap } from 'lit/directives/class-map.js';
 
 import style from './bl-dropdown.css';
 
@@ -18,6 +9,7 @@ import { ButtonSize, ButtonVariant, ButtonKind } from '../button/bl-button';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import BlDropdownItem, { blDropdownItemTag } from './item/bl-dropdown-item';
+import BlPopover from '../popover/bl-popover';
 
 export type CleanUpFunction = () => void;
 
@@ -33,13 +25,8 @@ export default class BlDropdown extends LitElement {
     return [style];
   }
 
-  @query('bl-button')
-  private _dropdownButton: HTMLElement;
-
-  @query('.popover')
-  private _popover: HTMLElement;
-
-  private _cleanUpPopover: CleanUpFunction | null = null;
+  @query('bl-popover')
+  private _popover: BlPopover;
 
   @state() private _isPopoverOpen = false;
 
@@ -89,8 +76,6 @@ export default class BlDropdown extends LitElement {
   }
   disconnectedCallback() {
     super.disconnectedCallback();
-
-    this._cleanUpPopover && this._cleanUpPopover();
     this.removeEventListener('keydown', this.handleKeyDown);
   }
 
@@ -100,36 +85,6 @@ export default class BlDropdown extends LitElement {
 
   private _handleClick() {
     !this._isPopoverOpen && !this.disabled ? this.open() : this.close();
-  }
-
-  private _handleClickOutside = (event: MouseEvent) => {
-    const eventPath = event.composedPath() as HTMLElement[];
-    if (!eventPath.includes(this._popover) && !eventPath.includes(this._dropdownButton)) {
-      this.close();
-    }
-  };
-
-  private _setupPopover() {
-    this._cleanUpPopover = autoUpdate(this._dropdownButton, this._popover, () => {
-      computePosition(this._dropdownButton, this._popover, {
-        placement: 'bottom-start',
-        strategy: 'fixed',
-        middleware: [
-          flip(),
-          offset(8),
-          size({
-            apply(args: MiddlewareArguments) {
-              Object.assign(args.elements.floating.style, {
-                minWidth: `${args.elements.reference.getBoundingClientRect().width}px`,
-              });
-            },
-          }),
-        ],
-      }).then(({ x, y }) => {
-        this._popover.style.setProperty('--left', `${x}px`);
-        this._popover.style.setProperty('--top', `${y}px`);
-      });
-    });
   }
 
   private focusedOptionIndex = -1;
@@ -169,24 +124,17 @@ export default class BlDropdown extends LitElement {
 
   open() {
     this._isPopoverOpen = true;
-    this._setupPopover();
+    this._popover.show();
     this.onOpen('Dropdown opened!');
-    document.addEventListener('click', this._handleClickOutside);
   }
 
   close() {
     this._isPopoverOpen = false;
+    this._popover.visible && this._popover.hide();
     this.onClose('Dropdown closed!');
-    this._cleanUpPopover && this._cleanUpPopover();
-    document.removeEventListener('click', this._handleClickOutside);
   }
 
   render(): TemplateResult {
-    const popoverClasses = classMap({
-      popover: true,
-      visible: this.opened,
-    });
-
     return html`<bl-button
         dropdown
         .active=${this.opened}
@@ -199,9 +147,9 @@ export default class BlDropdown extends LitElement {
       >
         ${this.label}
       </bl-button>
-      <div class="${popoverClasses}" role="menu" aria-expanded="${this.opened}">
+      <bl-popover .target="${this}" placement="bottom-start" @bl-popover-hide="${this.close}">
         <slot></slot>
-      </div> `;
+      </bl-popover> `;
   }
 }
 

--- a/src/components/dropdown/bl-dropdown.ts
+++ b/src/components/dropdown/bl-dropdown.ts
@@ -147,7 +147,12 @@ export default class BlDropdown extends LitElement {
       >
         ${this.label}
       </bl-button>
-      <bl-popover .target="${this}" placement="bottom-start" @bl-popover-hide="${this.close}">
+      <bl-popover
+        .target="${this}"
+        fit-size
+        placement="bottom-start"
+        @bl-popover-hide="${this.close}"
+      >
         <slot></slot>
       </bl-popover> `;
   }

--- a/src/components/dropdown/bl-dropdown.ts
+++ b/src/components/dropdown/bl-dropdown.ts
@@ -5,13 +5,11 @@ import { event, EventDispatcher } from '../../utilities/event';
 import style from './bl-dropdown.css';
 
 import '../button/bl-button';
-import { ButtonSize, ButtonVariant, ButtonKind } from '../button/bl-button';
+import BlButton, { ButtonSize, ButtonVariant, ButtonKind } from '../button/bl-button';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import BlDropdownItem, { blDropdownItemTag } from './item/bl-dropdown-item';
 import BlPopover from '../popover/bl-popover';
-
-export type CleanUpFunction = () => void;
 
 export const blDropdownTag = 'bl-dropdown';
 
@@ -27,6 +25,9 @@ export default class BlDropdown extends LitElement {
 
   @query('bl-popover')
   private _popover: BlPopover;
+
+  @query('bl-button')
+  private _button: BlButton;
 
   @state() private _isPopoverOpen = false;
 
@@ -74,9 +75,16 @@ export default class BlDropdown extends LitElement {
     super.connectedCallback();
     this.addEventListener('keydown', this.handleKeyDown);
   }
+
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeEventListener('keydown', this.handleKeyDown);
+  }
+
+  firstUpdated() {
+    // `_button` will be undefined during the initial render.
+    // To ensure proper rendering, we set `_popover.target` after the template has been created.
+    this._popover.target = this._button;
   }
 
   get opened() {
@@ -148,7 +156,6 @@ export default class BlDropdown extends LitElement {
         ${this.label}
       </bl-button>
       <bl-popover
-        .target="${this}"
         fit-size
         placement="bottom-start"
         @bl-popover-hide="${this.close}"

--- a/src/components/popover/bl-popover.ts
+++ b/src/components/popover/bl-popover.ts
@@ -112,7 +112,7 @@ export default class BlPopover extends LitElement {
           apply(args: MiddlewareState) {
             if (args.elements.floating && args.elements.reference) {
               Object.assign(args.elements.floating.style, {
-                width: `${args.elements.reference.getBoundingClientRect().width}px`,
+                'min-width': `${args.elements.reference.getBoundingClientRect().width}px`,
               });
             }
           },


### PR DESCRIPTION
This PR implements using popover component inside dropdown component by replacing local implementation. To do that we needed to change `fit-size` behaviour of popover. If `fit-size` set, popover will have the minimum size of it's trigger element. If content will be larger, than popover will increase until it's max-width.

Fixes #480