### PR TITLE
fix(dialog): prevent exiting browser fullscreen with dialog close

### DIFF
--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -98,6 +98,7 @@ export default class BlDialog extends LitElement {
 
   private onKeydown = (event: KeyboardEvent): void => {
     if (event.code === 'Escape' && this.open) {
+      event.preventDefault();
       this.closeDialog();
     }
   };


### PR DESCRIPTION
When dialog opens and being closed by user with `Escape` key, event prevented to avoid exiting browser from fullscreen.

Fixes #542 