### PR TITLE
fix(select): separator is back

### DIFF
--- a/src/components/select/option/bl-select-option.css
+++ b/src/components/select/option/bl-select-option.css
@@ -9,7 +9,7 @@
   --option-hover-color: var(--bl-color-primary-highlight);
   --option-color: var(--bl-color-neutral-darker);
   --option-disabled-color: var(--bl-color-neutral-light);
-  --option-seperator: 1px solid var(--bl-color-neutral-lighter);
+  --option-separator: 1px solid var(--bl-color-neutral-lighter);
   --option-gap: var(--bl-size-2xs);
   --option-transition: color 120ms ease-out;
 }


### PR DESCRIPTION
We noticed that we broke select item separator while we merge stuff. This fixes it.