### PR TITLE
fix(dialog): fire dialog close / open events by checking current open status

### DIFF
--- a/src/components/dialog/bl-dialog.test.ts
+++ b/src/components/dialog/bl-dialog.test.ts
@@ -303,7 +303,7 @@ describe('bl-dialog', () => {
       });
 
       it('should not fire bl-dialog-close event when dialog open prop is false in default', async () => {
-        const el = await fixture<typeOfBlDialog>(html`<bl-dialog :open="false" caption="My title">
+        const el = await fixture<typeOfBlDialog>(html`<bl-dialog .open=${false} caption="My title">
         </bl-dialog>`);
 
         setTimeout(async () => {

--- a/src/components/dialog/bl-dialog.test.ts
+++ b/src/components/dialog/bl-dialog.test.ts
@@ -301,6 +301,16 @@ describe('bl-dialog', () => {
           expect(ev.detail.isOpen).to.equal(false);
         });
       });
+
+      it('should not fire bl-dialog-close event when dialog open prop is false in default', async () => {
+        const el = await fixture<typeOfBlDialog>(html`<bl-dialog :open="false" caption="My title">
+        </bl-dialog>`);
+
+        setTimeout(async () => {
+          const ev = await oneEvent(el, 'bl-dialog-close');
+          expect(ev).to.not.exist;
+        });
+      });
     });
   });
 });

--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -54,7 +54,7 @@ export default class BlDialog extends LitElement {
   @event('bl-dialog-close') private onClose: EventDispatcher<object>;
 
   updated(changedProperties: PropertyValues<this>) {
-    if (changedProperties.has('open') && changedProperties.get('open') !== undefined || this.open){
+    if (changedProperties.has('open') && changedProperties.get('open') !== undefined || this.open) {
       this.toggleDialogHandler();
     }
   }
@@ -75,7 +75,7 @@ export default class BlDialog extends LitElement {
       this.toggleFooterShadow();
       window?.addEventListener('keydown', event => this.onKeydown(event));
       window?.addEventListener('resize', () => this.toggleFooterShadow());
-    } else if(!this.open) {
+    } else {
       this.dialog?.close?.();
       this.onClose({ isOpen: false });
       document.body.style.overflow = 'auto';

--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -54,7 +54,7 @@ export default class BlDialog extends LitElement {
   @event('bl-dialog-close') private onClose: EventDispatcher<object>;
 
   updated(changedProperties: PropertyValues<this>) {
-    if (changedProperties.has('open') && changedProperties.get('open') !== undefined || this.open) {
+    if (changedProperties.has('open') && (changedProperties.get('open') !== undefined || this.open)) {
       this.toggleDialogHandler();
     }
   }

--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -55,7 +55,7 @@ export default class BlDialog extends LitElement {
 
   updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has('open')) {
-      this.toggleDialogHandler();
+      this.toggleDialogHandler(changedProperties.get('open'));
     }
   }
 
@@ -67,15 +67,15 @@ export default class BlDialog extends LitElement {
     return [...this.childNodes].some(node => node.nodeName === 'BL-BUTTON');
   }
 
-  private toggleDialogHandler() {
-    if (this.open) {
+  private toggleDialogHandler(wasOpen: boolean) {
+    if (this.open && !wasOpen) {
       this.dialog?.showModal?.();
       this.onOpen({ isOpen: true });
       document.body.style.overflow = 'hidden';
       this.toggleFooterShadow();
       window?.addEventListener('keydown', event => this.onKeydown(event));
       window?.addEventListener('resize', () => this.toggleFooterShadow());
-    } else {
+    } else if(!this.open && wasOpen) {
       this.dialog?.close?.();
       this.onClose({ isOpen: false });
       document.body.style.overflow = 'auto';

--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -54,8 +54,8 @@ export default class BlDialog extends LitElement {
   @event('bl-dialog-close') private onClose: EventDispatcher<object>;
 
   updated(changedProperties: PropertyValues<this>) {
-    if (changedProperties.has('open')) {
-      this.toggleDialogHandler(changedProperties.get('open'));
+    if (changedProperties.has('open') && changedProperties.get('open') !== undefined || this.open){
+      this.toggleDialogHandler();
     }
   }
 
@@ -67,15 +67,15 @@ export default class BlDialog extends LitElement {
     return [...this.childNodes].some(node => node.nodeName === 'BL-BUTTON');
   }
 
-  private toggleDialogHandler(wasOpen: boolean) {
-    if (this.open && !wasOpen) {
+  private toggleDialogHandler() {
+    if (this.open) {
       this.dialog?.showModal?.();
       this.onOpen({ isOpen: true });
       document.body.style.overflow = 'hidden';
       this.toggleFooterShadow();
       window?.addEventListener('keydown', event => this.onKeydown(event));
       window?.addEventListener('resize', () => this.toggleFooterShadow());
-    } else if(!this.open && wasOpen) {
+    } else if(!this.open) {
       this.dialog?.close?.();
       this.onClose({ isOpen: false });
       document.body.style.overflow = 'auto';


### PR DESCRIPTION
This pull request prevents firing bl-dialog-close event automatically when the component is created with open=false property.
Fixes: #561