### PR TITLE
fix: set package type as module

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,7 +6,8 @@ module.exports = {
   },
   extends: ['eslint:recommended', 'prettier', 'plugin:storybook/recommended'],
   env: {
-    browser: true
+    browser: true,
+    node: true
   },
   globals: {
     process: 'readonly'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@trendyol/baklava",
+  "type": "module",
   "version": "0.0.0-dev",
   "description": "Trendyol Baklava Design System",
   "main": "dist/baklava.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,7 @@
-const esbuild = require('esbuild');
-const parseArgs = require('minimist');
-const del = require('del');
-const { litCssPlugin } = require('esbuild-plugin-lit-css');
+import { context, build } from 'esbuild';
+import parseArgs from 'minimist';
+import del from 'del';
+import { litCssPlugin } from 'esbuild-plugin-lit-css';
 
 const args = parseArgs(process.argv.slice(2), {
   boolean: true,
@@ -62,7 +62,7 @@ const args = parseArgs(process.argv.slice(2), {
     if (args.serve) {
       const servedir = 'playground';
 
-      let ctx = await esbuild.context({
+      let ctx = await context({
         ...buildOptions,
         outdir: `${servedir}/dist`
       });
@@ -79,7 +79,7 @@ const args = parseArgs(process.argv.slice(2), {
       return;
     }
 
-    const { errors, warnings, metafile } = await esbuild.build(buildOptions);
+    const { errors, warnings, metafile } = await build(buildOptions);
 
     if (errors.length > 0) {
       console.table(errors);

--- a/scripts/generate-react-exports.js
+++ b/scripts/generate-react-exports.js
@@ -1,6 +1,11 @@
-const fs = require('fs-extra');
-const prettier = require('prettier');
-const { pascalCase } = require('pascal-case');
+import fs from 'fs-extra';
+import { format } from 'prettier';
+import { pascalCase } from 'pascal-case';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const importStatements = [
   'import React from "react";',
@@ -16,7 +21,7 @@ function writeBaklavaReactFile(fileContentParts) {
     `// @ts-nocheck\n` +
     `${importStatements.join('\n')}\n\n` +
     `${fileContentParts.join('\n\n')}\n`;
-  const codeResult = prettier.format(fileContentText, { parser: 'typescript' });
+  const codeResult = format(fileContentText, { parser: 'typescript' });
 
   fs.writeFileSync(`${__dirname}/../src/baklava-react.ts`, codeResult);
 }
@@ -30,7 +35,8 @@ function cleanGenericTypes(typeParameters, eventType) {
 
   typeParameters?.forEach(param => {
     // TODO: This is a very naive implementation, it should be improved
-    result = result.replace(`<${param.name}>`, '')
+    result = result
+      .replace(`<${param.name}>`, '')
       .replace(`${param.name} | `, '')
       .replace(` | ${param.name}`, '');
   });


### PR DESCRIPTION
This pull request adds the "type: module" field to the package.json file. This change is made to indicate that our component library uses ECMAScript (ES) modules syntax and is designed to be consumed as an ES module.

Motivation:
By adding "type: module", we explicitly inform the JavaScript runtime and developers that our library follows the ES modules standard. This helps in promoting interoperability and enables seamless integration with modern JavaScript environments that natively support ES modules.

Benefits:
1. Clearer intent: By explicitly stating that our library uses ES modules, it becomes easier for developers to understand and utilize the library in projects that support ES modules.

2. Improved interoperability: With "type: module" specified, consumers of our library using tools like bundlers, module loaders, or build systems that understand ES modules can effortlessly incorporate our library into their projects.

3. Consistency: This change aligns our library with the industry trend of adopting ES modules, allowing for consistency across different projects and libraries that leverage ES modules.

Note:
Adding "type: module" implies that our library will not be compatible with older environments that only support CommonJS syntax. If we need to support both CommonJS and ES modules, we can explore using a build tool like Babel to transpile the code into CommonJS format and include both versions in the package.