### PR TITLE
fix(popover): dont take up space in layour when popover is hidden

### DIFF
--- a/src/components/popover/bl-popover.css
+++ b/src/components/popover/bl-popover.css
@@ -1,3 +1,7 @@
+:host {
+  display: contents;
+}
+
 .popover {
   --arrow-display: var(--bl-popover-arrow-display, none);
   --background-color: var(--bl-popover-background-color, var(--bl-color-neutral-full));


### PR DESCRIPTION
With the same reason of #579, this PR adds `display: contents` to the host element of popover component.