### PR TITLE
fix(checkbox): wrong aria label definition removed

### DIFF
--- a/src/components/checkbox-group/checkbox/bl-checkbox.test.ts
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.test.ts
@@ -15,7 +15,6 @@ describe('bl-checkbox', () => {
       `
         <label>
             <input type="checkbox"
-              aria-labelledby="label"
               aria-readonly="false"
               aria-required="false" />
             <div class="check-mark"></div>

--- a/src/components/checkbox-group/checkbox/bl-checkbox.ts
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.ts
@@ -139,7 +139,6 @@ export default class BlCheckbox extends FormControlMixin(LitElement) {
           .checked=${live(this.checked)}
           ?disabled=${this.disabled}
           aria-required=${this.required}
-          aria-labelledby="label"
           aria-readonly=${this.disabled}
           .indeterminate=${this.indeterminate}
           @change=${this.handleChange}


### PR DESCRIPTION
The wrong `aria-labelledby` definition was removed since checkbox is already wrapped with a label element.