### PR TITLE
fix(dialog): no bottom padding for content if actions exists

### DIFF
--- a/src/components/dialog/bl-dialog.css
+++ b/src/components/dialog/bl-dialog.css
@@ -72,8 +72,12 @@ header h2 {
 }
 
 .content {
-  padding: var(--bl-size-xl) var(--bl-size-xl) var(--bl-size-m) var(--bl-size-xl);
+  padding: var(--bl-size-xl);
   overflow: auto;
+}
+
+.container.has-footer .content {
+  padding-bottom: 0;
 }
 
 footer {

--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -1,6 +1,7 @@
 import { CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { event, EventDispatcher } from '../../utilities/event';
+import { classMap } from 'lit/directives/class-map.js';
 import '../button/bl-button';
 import style from './bl-dialog.css';
 
@@ -124,7 +125,12 @@ export default class BlDialog extends LitElement {
   private renderContainer() {
     const title = this.caption ? html`<h2 id="dialog-caption">${this.caption}</h2>` : '';
 
-    return html` <div class="container">
+    const classes = {
+      container: true,
+      'has-footer': this._hasFooter,
+    };
+
+    return html` <div class="${classMap(classes)}">
       <header>
         ${title}
         <bl-button


### PR DESCRIPTION
This remove the bottom padding of content area in case of a dialog actions are present. (Outcome of the decision in #600)

@buseselvi If this works for you can you update figma document accordingly?

Fixes #600 