### PR TITLE
feat(button): form property added for setting target form

### DIFF
--- a/src/components/button/bl-button.stories.mdx
+++ b/src/components/button/bl-button.stories.mdx
@@ -257,10 +257,43 @@ ${SingleButtonHoverTemplate({kind: 'danger', content: 'Danger Button', ...args})
   </Story>
 </Canvas>
 
+## Using Button with Forms
 
+Button can be used as the submit button of an HTML form. To use it as a submit button, you need to set `type` attribute to `submit`.
 
+```html
+<form action="/form/message" method="POST">
+  <bl-textarea name="message" placeholder="Your message"></bl-textarea>
+  <bl-button type="submit">Send</bl-button>
+</form>
+```
 
+In the example above, button automatically finds its wrapping form and submits it when clicked (by triggering validations, if needed).
+If you need to put a button outside of a form, you can set `form` attribute to the id of the form.
 
+```html
+<form id="contactForm" action="/form/message" method="POST">
+  <bl-textarea name="message" placeholder="Your message"></bl-textarea>
+</form>
+
+<bl-button form="contactForm" type="submit">Send</bl-button>
+```
+
+You can also set `form` **property** with a reference to an HTMLFormElement with JS in case you need:
+
+```html
+<form id="contactForm" action="/form/message" method="POST">
+  <bl-textarea name="message" placeholder="Your message"></bl-textarea>
+</form>
+
+<bl-button type="submit">Send</bl-button>
+
+<script>
+  const contactForm = document.getElementById('contactForm');
+  const button = document.querySelector('bl-button');
+  button.form = contactForm;
+</script>
+```
 
 ## Reference
 

--- a/src/components/button/bl-button.test.ts
+++ b/src/components/button/bl-button.test.ts
@@ -174,5 +174,33 @@ describe('bl-button', () => {
       const ev = await oneEvent(form, 'submit');
       expect(ev).to.exist;
     });
+
+    it('should submit form that is specified in form attribute', async () => {
+      const el = await fixture(html`<div><form id="form"></form>
+        <bl-button form="form" type="submit">button</bl-button></div>`);
+      const form = el.querySelector('form') as HTMLFormElement;
+      form.addEventListener('submit', e => e.preventDefault());
+
+      const button = el.querySelector('bl-button')?.shadowRoot?.querySelector('button');
+
+      setTimeout(() => button?.click());
+      const ev = await oneEvent(form, 'submit');
+      expect(ev).to.exist;
+    });
+
+    it('should submit form that is specified in form property', async () => {
+      const el = await fixture(html`<div><form></form>
+        <bl-button type="submit">button</bl-button></div>`);
+      const form = el.querySelector('form') as HTMLFormElement;
+      form.addEventListener('submit', e => e.preventDefault());
+      const blButton = el.querySelector('bl-button') as typeOfBlButton;
+      blButton.form = form;
+
+      const button = el.querySelector('bl-button')?.shadowRoot?.querySelector('button');
+
+      setTimeout(() => button?.click());
+      const ev = await oneEvent(form, 'submit');
+      expect(ev).to.exist;
+    });
   });
 });

--- a/src/components/button/bl-button.ts
+++ b/src/components/button/bl-button.ts
@@ -90,7 +90,7 @@ export default class BlButton extends LitElement {
    * Sets the type of the button. Set `submit` to use button as the submitter of parent form.
    */
   @property({ type: String })
-  type: 'submit' | null;
+  type: 'submit';
 
   /**
    * Sets button type to dropdown
@@ -103,6 +103,13 @@ export default class BlButton extends LitElement {
    */
   @property({ type: Boolean, reflect: true })
   autofocus = false;
+
+
+  /**
+   * Sets the associated form of the button. Use when `type` is set to `submit` and button is not inside the target form.
+   */
+  @property({ type: String })
+  form: HTMLFormElement | string;
 
   /**
    * Active state
@@ -122,11 +129,8 @@ export default class BlButton extends LitElement {
     return this.active;
   }
 
-  private form: HTMLFormElement | null;
-
   connectedCallback() {
     super.connectedCallback();
-    this.form = this.closest('form');
   }
 
   private caretTemplate(): TemplateResult {
@@ -135,8 +139,20 @@ export default class BlButton extends LitElement {
   }
 
   private _handleClick() {
-    if (this.type === 'submit' && this.form) {
-      submit(this.form);
+    if (this.type === 'submit') {
+      let targetForm: HTMLFormElement;
+
+      if (this.form instanceof HTMLFormElement) {
+        targetForm = this.form;
+      } else if (typeof this.form === 'string') {
+        targetForm = document.getElementById(this.form) as HTMLFormElement;
+      } else {
+        targetForm = this.closest('form') as HTMLFormElement;
+      }
+
+      if (targetForm) {
+        submit(targetForm);
+      }
     }
 
     this.onClick('Click event fired!');


### PR DESCRIPTION
This PR adds `form` property to the button to be able to target an HTML form that is not wrapping the button. I added some documentation as well to explain how to use button with forms as a submitter.

Closes #603 