### PR TITLE
fix(input): wait for update to set custom error

### DIFF
--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -221,7 +221,8 @@ export default class BlInput extends FormControlMixin(LitElement) {
   /**
    * Force to set input as in invalid state.
    */
-  forceCustomError() {
+  async forceCustomError() {
+    await this.updateComplete;
     this.validationTarget.setCustomValidity(this.customInvalidText || 'An error occurred');
     this.setValue(this.value);
     this.reportValidity();
@@ -230,7 +231,8 @@ export default class BlInput extends FormControlMixin(LitElement) {
   /**
    * Clear forced invalid state
    */
-  clearCustomError() {
+  async clearCustomError() {
+    await this.updateComplete;
     this.validationTarget.setCustomValidity('');
     this.setValue(this.value);
     this.reportValidity();


### PR DESCRIPTION
`forceCustomError` and `clearCustomError` methods need to use `validationTarget` property which becomes ready after a full update of the input component. This PR makes sure that those methods wait for finishing the rendering cycle to set/clear custom validation state of the internal input.

Fixes #611 