### PR TITLE
feat(dialog): add `polyfilled` property for setting native or polyfill

### DIFF
--- a/src/components/dialog/bl-dialog.stories.ts
+++ b/src/components/dialog/bl-dialog.stories.ts
@@ -23,7 +23,7 @@ const meta: Meta = {
     open: {
       control: "boolean",
     },
-    levelled: {
+    polyfilled: {
       control: "boolean",
     },
     caption: {
@@ -42,7 +42,7 @@ interface DialogArgs {
   className?: string;
   caption?: string;
   open?: boolean;
-  levelled?: boolean;
+  polyfilled?: boolean;
   content?: string;
   primaryAction?: string;
   secondaryAction?: string;
@@ -67,7 +67,7 @@ const BasicTemplate = (args: DialogArgs) => html`
   class="${ifDefined(args.className)}"
   caption="${ifDefined(args.caption)}"
   ?open="${args.open}"
-  ?levelled="${args.levelled}">
+  ?polyfilled="${args.polyfilled}">
     ${
       unsafeHTML(args.content)
     }${

--- a/src/components/dialog/bl-dialog.stories.ts
+++ b/src/components/dialog/bl-dialog.stories.ts
@@ -23,6 +23,9 @@ const meta: Meta = {
     open: {
       control: "boolean",
     },
+    levelled: {
+      control: "boolean",
+    },
     caption: {
       control: "text"
     },
@@ -39,6 +42,7 @@ interface DialogArgs {
   className?: string;
   caption?: string;
   open?: boolean;
+  levelled?: boolean;
   content?: string;
   primaryAction?: string;
   secondaryAction?: string;
@@ -62,7 +66,8 @@ const BasicTemplate = (args: DialogArgs) => html`
   id=${args.id}
   class="${ifDefined(args.className)}"
   caption="${ifDefined(args.caption)}"
-  ?open="${args.open}">
+  ?open="${args.open}"
+  ?levelled="${args.levelled}">
     ${
       unsafeHTML(args.content)
     }${

--- a/src/components/dialog/bl-dialog.test.ts
+++ b/src/components/dialog/bl-dialog.test.ts
@@ -351,7 +351,7 @@ describe('bl-dialog', () => {
 
         const closeBtn = el?.shadowRoot?.querySelector('bl-button');
 
-        el.addEventListener('bl-dialog-request-close', (ev) => {
+        el.addEventListener('bl-dialog-request-close', ev => {
           ev.preventDefault();
         });
 
@@ -361,7 +361,7 @@ describe('bl-dialog', () => {
 
         await oneEvent(el, 'bl-dialog-request-close');
 
-        expect(el.open).to.be.true
+        expect(el.open).to.be.true;
       });
     });
   });

--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -23,13 +23,17 @@ export default class BlDialog extends LitElement {
   /**
    * Sets dialog open-close status
    */
-  @property({ type: Boolean, reflect: true, hasChanged(newVal: boolean, oldVal: boolean | undefined) {
-    if (newVal === false && oldVal === undefined) {
-      // Assume that the initial value is false
-      return false;
-    }
-    return newVal !== oldVal;
-  } })
+  @property({
+    type: Boolean,
+    reflect: true,
+    hasChanged(newVal: boolean, oldVal: boolean | undefined) {
+      if (newVal === false && oldVal === undefined) {
+        // Assume that the initial value is false
+        return false;
+      }
+      return newVal !== oldVal;
+    },
+  })
   open = false;
 
   /**
@@ -37,6 +41,12 @@ export default class BlDialog extends LitElement {
    */
   @property({ type: String })
   caption?: string;
+
+  /**
+   * Sets whether to use the native dialog element.
+   */
+  @property({ type: Boolean })
+  levelled = !window.HTMLDialogElement;
 
   @query('.dialog')
   private dialog: HTMLDialogElement & DialogElement;
@@ -59,7 +69,9 @@ export default class BlDialog extends LitElement {
    * Fires before the dialog is closed with internal actions like clicking close button,
    * pressing Escape key or clicking backdrop. Can be prevented by calling `event.preventDefault()`
    */
-  @event('bl-dialog-request-close') private onRequestClose: EventDispatcher<{ source: 'close-button' | 'keyboard' | 'backdrop' }>;
+  @event('bl-dialog-request-close') private onRequestClose: EventDispatcher<{
+    source: 'close-button' | 'keyboard' | 'backdrop';
+  }>;
 
   /**
    * Fires when the dialog is closed
@@ -70,10 +82,6 @@ export default class BlDialog extends LitElement {
     if (changedProperties.has('open')) {
       this.toggleDialogHandler();
     }
-  }
-
-  private get hasHtmlDialogSupport() {
-    return !!window.HTMLDialogElement;
   }
 
   private get _hasFooter() {
@@ -144,7 +152,7 @@ export default class BlDialog extends LitElement {
     const title = this.caption ? html`<h2 id="dialog-caption">${this.caption}</h2>` : '';
 
     const classes = {
-      container: true,
+      'container': true,
       'has-footer': this._hasFooter,
     };
 
@@ -164,8 +172,16 @@ export default class BlDialog extends LitElement {
   }
 
   render(): TemplateResult {
-    return this.hasHtmlDialogSupport
-      ? html`
+    return this.levelled
+      ? html`<div
+          class="dialog-polyfill"
+          role="dialog"
+          aria-labelledby="dialog-caption"
+          @click=${this.clickOutsideHandler}
+        >
+          ${this.renderContainer()}
+        </div>`
+      : html`
           <dialog
             class="dialog"
             aria-labelledby="dialog-caption"
@@ -173,15 +189,7 @@ export default class BlDialog extends LitElement {
           >
             ${this.renderContainer()}
           </dialog>
-        `
-      : html`<div
-          class="dialog-polyfill"
-          role="dialog"
-          aria-labelledby="dialog-caption"
-          @click=${this.clickOutsideHandler}
-        >
-          ${this.renderContainer()}
-        </div>`;
+        `;
   }
 }
 

--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -43,10 +43,14 @@ export default class BlDialog extends LitElement {
   caption?: string;
 
   /**
-   * Sets whether to use the native dialog element.
+   * Determines if dialog currently uses polyfilled version instead of native HTML Dialog. By
+   * default, it uses native Dialog if the browser supports it, otherwise polyfills. You can force
+   * using polyfill by setting this to true in some cases like to show some content on top of dialog
+   * in case you are not able to use Popover API. Be aware that, polyfilled version can cause some
+   * inconsistencies in terms of accessibility and stacking context. So use it with extra caution.
    */
   @property({ type: Boolean, reflect: true })
-  levelled = !window.HTMLDialogElement;
+  polyfilled = !window.HTMLDialogElement;
 
   @query('.dialog')
   private dialog: HTMLDialogElement & DialogElement;
@@ -79,7 +83,7 @@ export default class BlDialog extends LitElement {
   @event('bl-dialog-close') private onClose: EventDispatcher<object>;
 
   updated(changedProperties: PropertyValues<this>) {
-    if (changedProperties.has('open') || changedProperties.has('levelled')) {
+    if (changedProperties.has('open') || changedProperties.has('polyfilled')) {
       this.toggleDialogHandler();
     }
   }
@@ -172,7 +176,7 @@ export default class BlDialog extends LitElement {
   }
 
   render(): TemplateResult {
-    return this.levelled
+    return this.polyfilled
       ? html`<div
           class="dialog-polyfill"
           role="dialog"

--- a/src/components/dialog/bl-dialog.ts
+++ b/src/components/dialog/bl-dialog.ts
@@ -45,7 +45,7 @@ export default class BlDialog extends LitElement {
   /**
    * Sets whether to use the native dialog element.
    */
-  @property({ type: Boolean })
+  @property({ type: Boolean, reflect: true })
   levelled = !window.HTMLDialogElement;
 
   @query('.dialog')
@@ -79,7 +79,7 @@ export default class BlDialog extends LitElement {
   @event('bl-dialog-close') private onClose: EventDispatcher<object>;
 
   updated(changedProperties: PropertyValues<this>) {
-    if (changedProperties.has('open')) {
+    if (changedProperties.has('open') || changedProperties.has('levelled')) {
       this.toggleDialogHandler();
     }
   }


### PR DESCRIPTION
A prop has been developed that we can set to use native or polyfill. The fastest solution for managing stacking context in browsers without Popover API. 

Fixes #617