### PR TITLE
fix(radio): radio button flex-shrink problem

### DIFF
--- a/src/components/radio-group/radio/bl-radio.css
+++ b/src/components/radio-group/radio/bl-radio.css
@@ -24,8 +24,10 @@
   content: '';
   display: inline-block;
   box-sizing: border-box;
-  width: var(--size);
-  height: var(--size);
+  min-width: var(--size);
+  min-height: var(--size);
+  max-width: var(--size);
+  max-height: var(--size);
   background-color: white;
   border-radius: var(--bl-border-radius-circle);
   border: solid 1px var(--bl-color-neutral-lighter);


### PR DESCRIPTION
I've noticed an issue with the `bl-radio` component where the radio button's size shrinks if the text within the `#label` element becomes too long. The `#label` element is a flex container, its `:before` pseudo-selector, which is used to create the radio button, is designed with strict width and height settings, leading to this behavior.

The cause of the radio button shrinking is tied to its `flex-shrink` property. However, applying `flex-shrink: 0;` to address this issue would be overly specific.

As a solution, I've implemented a `flex: none;` setting which prevents the radio button from shrinking.

I'm attaching a few example screenshots to illustrate the issue:

<img width="569" alt="246438482-cfee32d8-0a4d-4ddc-83c0-a3277cb34112" src="https://github.com/Trendyol/baklava/assets/12007317/1b0574ec-2a7b-4e12-85ba-3d63755432bb">

<img width="1343" alt="246438494-06740896-5d8e-44d7-a166-7ea6b3c36d32" src="https://github.com/Trendyol/baklava/assets/12007317/05e92fc1-49ab-46c9-b9af-0e8f14aab5a9">
