### PR TITLE
fix(tooltip): remove extra space

### DIFF
--- a/src/components/tooltip/bl-tooltip.css
+++ b/src/components/tooltip/bl-tooltip.css
@@ -7,11 +7,6 @@
   cursor: pointer;
 }
 
-.wrapper{
-  display: inline-block;
-  color: var(--bl-color-neutral-full);;
-}
-
 bl-popover {
   --bl-popover-background-color: var(--bl-color-neutral-darker);
   --bl-popover-arrow-display: block;

--- a/src/components/tooltip/bl-tooltip.test.ts
+++ b/src/components/tooltip/bl-tooltip.test.ts
@@ -1,8 +1,8 @@
 import { assert, elementUpdated, expect, fixture, html, oneEvent } from '@open-wc/testing';
-import {sendKeys, sendMouse} from '@web/test-runner-commands';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
 import BlTooltip from './bl-tooltip';
 import type typeOfBlTooltip from './bl-tooltip';
-import type typeOfBlPopover from "../popover/bl-popover";
+import type typeOfBlPopover from '../popover/bl-popover';
 
 describe('bl-tooltip', () => {
   it('should be defined tooltip instance', () => {
@@ -26,7 +26,6 @@ describe('bl-tooltip', () => {
        class="trigger"
        name="tooltip-trigger">
       </slot>
-      <div class="wrapper">
       <bl-popover placement="top">
         <slot
           class="content"
@@ -34,7 +33,6 @@ describe('bl-tooltip', () => {
           role="tooltip">
         </slot>
        </bl-popover>
-      </div>
       `
     );
   });

--- a/src/components/tooltip/bl-tooltip.ts
+++ b/src/components/tooltip/bl-tooltip.ts
@@ -78,16 +78,16 @@ export default class BlTooltip extends LitElement {
   }
 
   render(): TemplateResult {
-    return html` ${this.triggerTemplate()}
-      <div class="wrapper">
-        <bl-popover
-          .target="${this.trigger}"
-          placement="${ifDefined(this.placement)}"
-          @bl-popover-hide="${() => this.onHide('')}"
-          >
-          <slot class="content" id="tooltip" role="tooltip"></slot>
-        </bl-popover>
-      </div>`;
+    return html`
+      ${this.triggerTemplate()}
+      <bl-popover
+        .target="${this.trigger}"
+        placement="${ifDefined(this.placement)}"
+        @bl-popover-hide="${() => this.onHide('')}"
+      >
+        <slot class="content" id="tooltip" role="tooltip"></slot>
+      </bl-popover>
+    `;
   }
 }
 


### PR DESCRIPTION
<img width="232" alt="Screen Shot 2023-06-17 at 16 05 39" src="https://github.com/Trendyol/baklava/assets/10272532/5ceafc25-5c1e-4910-8935-6e3c6c105cd7">

the top input is the expected state and the bottom is the actual state. (look right gap)