### PR TITLE
feat(react): export react component types

### DIFF
--- a/scripts/generate-react-exports.js
+++ b/scripts/generate-react-exports.js
@@ -15,11 +15,14 @@ const importStatements = [
   'import { ISelectOption } from "./components/select/bl-select"',
 ];
 
+const exportStatements = [];
+
 function writeBaklavaReactFile(fileContentParts) {
   let fileContentText =
     `/* eslint-disable @typescript-eslint/ban-ts-comment */\n` +
     `// @ts-nocheck\n` +
     `${importStatements.join('\n')}\n\n` +
+    `${exportStatements.join('\n')}\n\n` +
     `${fileContentParts.join('\n\n')}\n`;
   const codeResult = format(fileContentText, { parser: 'typescript' });
 
@@ -77,6 +80,7 @@ for (const module of customElementsModules) {
   const Type = componentName + 'Type';
 
   importStatements.push(`import type ${Type} from "./${importPath}";`);
+  exportStatements.push(`export declare type ${Type.replace('Type', '')} = ${Type}`);
 
   const componentDefinition =
     typeParam => `  customElements.whenDefined('${fileName}').then(() => ({

--- a/scripts/generate-react-exports.js
+++ b/scripts/generate-react-exports.js
@@ -80,7 +80,7 @@ for (const module of customElementsModules) {
   const Type = componentName + 'Type';
 
   importStatements.push(`import type ${Type} from "./${importPath}";`);
-  exportStatements.push(`export declare type ${Type.replace('Type', '')} = ${Type}`);
+  exportStatements.push(`export declare type ${componentName} = ${Type}`);
 
   const componentDefinition =
     typeParam => `  customElements.whenDefined('${fileName}').then(() => ({


### PR DESCRIPTION
This PR adds support to use React components both as value and type.

Example usage:
```tsx
import { BlDialog } from "@trendyol/baklava/dist/baklava-react";

const Component = () => {
  const dialogRef = React.useRef<BlDialog>(null);

  return (
    <BlDialog ref={dialogRef}>...</BlDialog>
  )
}
```

Fixes #307 
