### PR TITLE
fix(input): remove type from input min/max

### DIFF
--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -84,13 +84,13 @@ export default class BlInput extends FormControlMixin(LitElement) {
   /**
    * Sets the smallest number can be entered to a `number` input
    */
-  @property({ type: Number, reflect: true })
+  @property({ reflect: true })
   min?: number;
 
   /**
    * Sets the biggest number can be entered to a `number` input
    */
-  @property({ type: Number, reflect: true })
+  @property({ reflect: true })
   max?: number;
 
   /**


### PR DESCRIPTION
This PR removes @property type from min and max attributes, thus it will allow input type="date" to be parsed correctly.

Fixes #612