### PR TITLE
docs: Update bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,7 +24,6 @@ body:
     attributes:
       label: Media & Screenshots
       description: Include screenshots or video of reproduction as much as possible
-      render: md
   - type: input
     id: baklava-version
     attributes:


### PR DESCRIPTION
Removes `render: md` from **Media & Screenshots** as it prevents uploading from clipboard.