### PR TITLE
feat(tooltip): add css variable for set display of tooltip trigger

### DIFF
--- a/src/components/tooltip/bl-tooltip.css
+++ b/src/components/tooltip/bl-tooltip.css
@@ -3,7 +3,7 @@
 }
 
 .trigger {
-  display: inline-flex;
+  display: var(--bl-tooltip-trigger-display, inline-flex);
   cursor: pointer;
 }
 

--- a/src/components/tooltip/bl-tooltip.ts
+++ b/src/components/tooltip/bl-tooltip.ts
@@ -13,7 +13,7 @@ import style from './bl-tooltip.css';
  * @summary Baklava Tooltip component
  * @dependency bl-popover
  *
- * @property {string} placement - Sets the tooltip placement
+ * @cssproperty [--bl-tooltip-trigger-display=inline-flex] Set the display of the tooltip trigger.
  */
 @customElement('bl-tooltip')
 export default class BlTooltip extends LitElement {


### PR DESCRIPTION
If you set an input to `width: 100%` and wrap it with the tooltip, you will see that the input shrinks, so we need to set it to `display: flex`.

<img width="308" alt="resim" src="https://github.com/Trendyol/baklava/assets/10272532/fc165f13-1aae-4ddd-86bc-e0e7b05546f0">
