### PR TITLE
feat(select): add select clearable prop

### DIFF
--- a/src/components/select/bl-select.stories.mdx
+++ b/src/components/select/bl-select.stories.mdx
@@ -157,10 +157,7 @@ The select component includes a clear button. Clear button can be displayed by p
   <Story name="Select With Clear Button" args={{ placeholder: "Choose country", value: 'tr', clearable: true }} play={selectOpener}>
     {SelectTemplate.bind({})}
   </Story>
-  <Story name="Required Select Without Clear Button" args={{ placeholder: "Choose country", value: 'tr', clearable: true }} play={selectOpener}>
-    {SelectTemplate.bind({})}
-  </Story>
-  <Story name="Required Multiple Select With Clear Button" args={{ placeholder: "Choose countries", value: ['nl'], multiple: true, clearable: true  }} play={selectOpener}>
+  <Story name="Multiple Select With Clear Button" args={{ placeholder: "Choose countries", value: ['nl'], multiple: true, clearable: true  }} play={selectOpener}>
     {SelectTemplate.bind({})}
   </Story>
 </Canvas>

--- a/src/components/select/bl-select.stories.mdx
+++ b/src/components/select/bl-select.stories.mdx
@@ -34,6 +34,9 @@ import { centeredLayout } from '../../utilities/chromatic-decorators';
     required: {
       control: 'boolean'
     },
+    clearable: {
+      control: 'boolean'
+    },
     disabled: {
       control: 'boolean'
     },
@@ -90,6 +93,7 @@ export const SelectTemplate = (args) => html`<bl-select
     label=${ifDefined(args.label)}
     ?label-fixed=${args.labelFixed}
     ?multiple=${args.multiple}
+    ?clearable=${args.clearable}
     ?required=${args.required}
     ?disabled=${args.disabled}
     ?success=${args.success}
@@ -147,17 +151,16 @@ Selected options will be visible on input seperated by commas.
 
 ## Clear Button
 
-The select component includes a clear button. For single select, the clear button is hidden when the `required` attribute is set.
-However, in multiple select, the clear button is always shown, irrespective of the `required` attribute.
+The select component includes a clear button. Clear button can be displayed by passing `clearable` attribute to the Select component.
 
 <Canvas>
-  <Story name="Select With Clear Button" args={{ placeholder: "Choose country", value: 'tr' }} play={selectOpener}>
+  <Story name="Select With Clear Button" args={{ placeholder: "Choose country", value: 'tr', clearable: true }} play={selectOpener}>
     {SelectTemplate.bind({})}
   </Story>
-  <Story name="Required Select Without Clear Button" args={{ placeholder: "Choose country", value: 'tr', required: true }} play={selectOpener}>
+  <Story name="Required Select Without Clear Button" args={{ placeholder: "Choose country", value: 'tr', clearable: true }} play={selectOpener}>
     {SelectTemplate.bind({})}
   </Story>
-  <Story name="Required Multiple Select With Clear Button" args={{ placeholder: "Choose countries", value: ['nl'], multiple: true, required: true  }} play={selectOpener}>
+  <Story name="Required Multiple Select With Clear Button" args={{ placeholder: "Choose countries", value: ['nl'], multiple: true, clearable: true  }} play={selectOpener}>
     {SelectTemplate.bind({})}
   </Story>
 </Canvas>

--- a/src/components/select/bl-select.test.ts
+++ b/src/components/select/bl-select.test.ts
@@ -138,7 +138,7 @@ describe('bl-select', () => {
     const removeAll = el.shadowRoot?.querySelector<BlButton>('.remove-all');
     expect(removeAll).to.exist;
   });
-  it('should remove selected option on remove all click on non-required single select', async () => {
+  it('should remove selected option on remove all click on single select with clearable prop', async () => {
     const el = await fixture<BlSelect>(html`<bl-select clearable>
       <bl-select-option value="1">Option 1</bl-select-option>
       <bl-select-option value="2" selected>Option 2</bl-select-option>

--- a/src/components/select/bl-select.test.ts
+++ b/src/components/select/bl-select.test.ts
@@ -2,7 +2,7 @@ import { assert, elementUpdated, expect, fixture, html, oneEvent } from '@open-w
 
 import BlSelect from './bl-select';
 import type BlSelectOption from './option/bl-select-option';
-import type BlButton from '../button/bl-button';
+import BlButton from '../button/bl-button';
 
 import BlCheckbox from '../checkbox-group/checkbox/bl-checkbox';
 import { sendKeys } from '@web/test-runner-commands';
@@ -34,14 +34,6 @@ describe('bl-select', () => {
             +0
           </span>
           <div class="actions">
-          <bl-button
-            class="remove-all"
-            icon="close"
-            kind="neutral"
-            size="small"
-            variant="tertiary"
-          >
-          </bl-button>
           <bl-icon class="dropdown-icon open" name="arrow_up"></bl-icon>
           <bl-icon class="dropdown-icon closed" name="arrow_down"></bl-icon>
           </div>
@@ -136,8 +128,18 @@ describe('bl-select', () => {
     expect(el.checkValidity()).to.false;
     expect(invalidText).to.exist;
   });
+  it('should render "remove all" button on clearable attribute is given', async () => {
+    const el = await fixture<BlSelect>(html`
+      <bl-select clearable>
+        <bl-select-option value="1">Option 1</bl-select-option>
+        <bl-select-option value="2" selected>Option 2</bl-select-option>
+      </bl-select>
+    `);
+    const removeAll = el.shadowRoot?.querySelector<BlButton>('.remove-all');
+    expect(removeAll).to.exist;
+  });
   it('should remove selected option on remove all click on non-required single select', async () => {
-    const el = await fixture<BlSelect>(html`<bl-select>
+    const el = await fixture<BlSelect>(html`<bl-select clearable>
       <bl-select-option value="1">Option 1</bl-select-option>
       <bl-select-option value="2" selected>Option 2</bl-select-option>
     </bl-select>`);
@@ -154,7 +156,7 @@ describe('bl-select', () => {
     expect(el.value).to.null;
   });
   it('should remove selected options', async () => {
-    const el = await fixture<BlSelect>(html`<bl-select multiple>
+    const el = await fixture<BlSelect>(html`<bl-select clearable multiple>
       <bl-select-option value="1">Option 1</bl-select-option>
       <bl-select-option value="2" selected>Option 2</bl-select-option>
     </bl-select>`);
@@ -378,9 +380,9 @@ describe('bl-select', () => {
   describe('keyboard navigation', () => {
     let el: HTMLDivElement, blSelect: BlSelect;
     const tabKey =
-        navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('HeadlessChrome')
-          ? 'Alt+Tab'
-          : 'Tab';
+      navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('HeadlessChrome')
+        ? 'Alt+Tab'
+        : 'Tab';
 
     beforeEach(async () => {
       //when

--- a/src/components/select/bl-select.test.ts
+++ b/src/components/select/bl-select.test.ts
@@ -156,7 +156,7 @@ describe('bl-select', () => {
     expect(el.value).to.null;
   });
   it('should remove selected options', async () => {
-    const el = await fixture<BlSelect>(html`<bl-select clearable multiple>
+    const el = await fixture<BlSelect>(html`<bl-select multiple>
       <bl-select-option value="1">Option 1</bl-select-option>
       <bl-select-option value="2" selected>Option 2</bl-select-option>
     </bl-select>`);

--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -291,16 +291,17 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
     const inputSelectedOptions = html`<ul class="selected-options">
       ${this._selectedOptions.map(item => html`<li>${item.textContent}</li>`)}
     </ul>`;
-    const removeButton = this.clearable
-      ? html`<bl-button
-          class="remove-all"
-          size="small"
-          variant="tertiary"
-          kind="neutral"
-          icon="close"
-          @click=${this._onClickRemove}
-        ></bl-button>`
-      : '';
+    const removeButton =
+      this.clearable || this.multiple
+        ? html`<bl-button
+            class="remove-all"
+            size="small"
+            variant="tertiary"
+            kind="neutral"
+            icon="close"
+            @click=${this._onClickRemove}
+          ></bl-button>`
+        : '';
 
     return html`<fieldset
       class=${classMap({

--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -320,7 +320,7 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
       ${inputSelectedOptions}
       <span class="additional-selection-count">+${this._additionalSelectedOptionCount}</span>
       <div class="actions">
-        ${this.multiple || !this.required ? removeButton : null}
+        ${removeButton}
         <bl-icon class="dropdown-icon open" name="arrow_up"></bl-icon>
 
         <bl-icon class="dropdown-icon closed" name="arrow_down"></bl-icon>

--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -1,11 +1,4 @@
-import {
-  autoUpdate,
-  computePosition,
-  flip,
-  MiddlewareState,
-  offset,
-  size,
-} from '@floating-ui/dom';
+import { autoUpdate, computePosition, flip, MiddlewareState, offset, size } from '@floating-ui/dom';
 import { FormControlMixin, requiredValidator } from '@open-wc/form-control';
 import { FormValue } from '@open-wc/form-helpers';
 import 'element-internals-polyfill';
@@ -42,7 +35,7 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
   static get styles(): CSSResultGroup {
     return [style];
   }
-  static shadowRootOptions = {...LitElement.shadowRootOptions, delegatesFocus: true};
+  static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
 
   static formControlValidators = [requiredValidator];
 
@@ -112,6 +105,12 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
+
+  /**
+   * Sets whether the selected option is clearable
+   */
+  @property({ type: Boolean })
+  clearable = false;
 
   /**
    * Allows multiple options to be selected
@@ -292,14 +291,16 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
     const inputSelectedOptions = html`<ul class="selected-options">
       ${this._selectedOptions.map(item => html`<li>${item.textContent}</li>`)}
     </ul>`;
-    const removeButton = html`<bl-button
-      class="remove-all"
-      size="small"
-      variant="tertiary"
-      kind="neutral"
-      icon="close"
-      @click=${this._onClickRemove}
-    ></bl-button>`;
+    const removeButton = this.clearable
+      ? html`<bl-button
+          class="remove-all"
+          size="small"
+          variant="tertiary"
+          kind="neutral"
+          icon="close"
+          @click=${this._onClickRemove}
+        ></bl-button>`
+      : '';
 
     return html`<fieldset
       class=${classMap({


### PR DESCRIPTION
This PR fixes the breaking change:
- Select component shouldn't have clear button by default, instead `clearable` attribute should be given to set it clearable