### PR TITLE
fix(checkbox): add stroke to checkbox disabled

### DIFF
--- a/src/components/checkbox-group/checkbox/bl-checkbox.css
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.css
@@ -61,6 +61,7 @@ input {
 :host([disabled]) .check-mark,
 :host([disabled]) .label {
   color: var(--bl-color-neutral-light);
+  border: 1px solid var(--bl-color-neutral-lighter);
 }
 
 :host([disabled]) .check-mark {


### PR DESCRIPTION
Noticed that we are not showing stroke in the Checkbox disabled variant.

Fixes #567