### PR TITLE
fix(tab): changing the tooltip button in the tab with help text to an…

### DIFF
--- a/src/components/tab-group/tab/bl-tab.ts
+++ b/src/components/tab-group/tab/bl-tab.ts
@@ -112,13 +112,7 @@ export default class BlTab extends LitElement {
     const helpTooltip = this.helpText
       ? html` <div class="help-container">
           <bl-tooltip>
-            <bl-button
-              slot="tooltip-trigger"
-              icon="info"
-              variant="tertiary"
-              kind="neutral"
-              label="${this.helpText}"
-            ></bl-button>
+            <bl-icon name="info" slot="tooltip-trigger"></bl-icon>
             ${this.helpText}
           </bl-tooltip>
         </div>`


### PR DESCRIPTION
<img width="648" alt="image" src="https://github.com/Trendyol/baklava/assets/49954227/fcd3105e-4b74-4e5d-a7a8-75d69bad0561">

The hover background of the button used for the tooltip is sticking to the text. There is no click action on the button. That's why I think it's unnecessary