### PR TITLE
fix(checkbox): breaking long words better

### DIFF
--- a/src/components/checkbox-group/checkbox/bl-checkbox.css
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.css
@@ -17,7 +17,7 @@ label {
 }
 
 .label {
-  word-break: break-all;
+  overflow-wrap: anywhere;
 }
 
 input {

--- a/src/components/checkbox-group/checkbox/bl-checkbox.stories.mdx
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.stories.mdx
@@ -143,10 +143,10 @@ If label doesn't fit the row and goes multiline, checkmark stays on top.
   </Story>
 </Canvas>
 
-Also if a single word doesn't fit the line, it also being forced to multiline (with `word-break: break-all;`).
+Also if a single word doesn't fit the line, it also being forced to multiline (with `overflow-wrap: break-word;`).
 
 <Canvas>
-  <Story name="A very long word" args={{ label: "Some/Very&LongSingleWord" }}>
+  <Story name="A very long word" args={{ label: "Some Short and Some/Very&LongSingleWords Together" }}>
     {CheckboxLimitedWidthTemplate.bind({})}
   </Story>
 </Canvas>


### PR DESCRIPTION
This PR proposes to use `overflow-wrap: anywhere` for checkbox label instead of `word-break: break-all` to provide better readability in case of long texts in small available space.

Fixes #682
Fixes #626 