### PR TITLE
feat(popover): allow nested popovers

### DIFF
--- a/src/components/popover/bl-popover.stories.mdx
+++ b/src/components/popover/bl-popover.stories.mdx
@@ -37,6 +37,11 @@ export const popoverOpener = async ({canvasElement}) => {
   }
 }
 
+export const nestedPopoverOpener = async ({canvasElement}) => {
+  await popoverOpener({ canvasElement });
+  await popoverOpener({ canvasElement: canvasElement.querySelector('#popover-nested-parent') });
+}
+
 export const handleClick = async (event,args) => {
   const popover = document.getElementById(`popover-${ifDefined(args.id)}`);
   popover.target = document.getElementById(`button-${ifDefined(args.id)}`);
@@ -50,7 +55,7 @@ export const PopoverTemplate = (args) => html`
   fit-size="${ifDefined(args.fitSize)}"
   offset="${ifDefined(args.offset)}"
   style="${ifDefined(args.style)}">
-  Popover Content
+  ${args.slot?.() || 'Popover Content'}
 </bl-popover>
   `
 
@@ -70,6 +75,16 @@ Popover Content
 </bl-popover>
 `
 
+export const NestedStoryTemplate = (args) => html`
+<style>
+  #popover-nested {
+    --bl-popover-arrow-display: block;
+  }
+</style>
+<bl-button id="button-${ifDefined(args.id)}" @bl-click="${(event) => handleClick(event,args)}" >${args.buttonText ? args.buttonText : 'Trigger Popover'}</bl-button>
+${PopoverTemplate({...args, slot: () => StoryTemplate({ id: 'nested', placement: 'right'}) })}
+`
+
 # Popover
 
 <bl-badge icon="document">[ADR](https://github.com/orgs/Trendyol/projects/4?pane=issue&itemId=14813896)</bl-badge>
@@ -87,7 +102,7 @@ Be cautious about using this component. Consider using semantically more releava
 ## Main behaviours
 
 * Popovers don't open by themself. `show()` method should be called via JavaScript when desired.
-* Only a single popover can be visible in the screen at the same time. Whenever a popover is shown, other one will close itself automatically.
+* Only a single popover can be visible in the screen at the same time. Whenever another popover is shown, other one will close itself automatically, unless they are nested.
 * Popovers tries to keep themself inside viewport. For example: If you place it to bottom of an element and if there is not enough space to show it below, it automatically flips to the top of the element.
 * Popovers can be closed with `Escape` key.
 * Popovers close themself if user clicks outside of it and its target element.
@@ -132,6 +147,16 @@ Or by passing targert reference:
   </Story>
   <Story name="Show popover with instance trigger" args={{ buttonText:'Trigger with instance' ,id:'2' }} play={popoverOpener}>
     {TargetInstanceStoryTemplate.bind({})}
+  </Story>
+</Canvas>
+
+## Nested Popovers
+
+You can nest popovers inside each other.
+
+<Canvas>
+  <Story name="Nested Popovers" args={{ buttonText:'Nested Popovers', id: 'nested-parent' }} play={nestedPopoverOpener}>
+    {NestedStoryTemplate.bind()}
   </Story>
 </Canvas>
 

--- a/src/components/popover/bl-popover.stories.mdx
+++ b/src/components/popover/bl-popover.stories.mdx
@@ -39,6 +39,8 @@ export const popoverOpener = async ({canvasElement}) => {
 
 export const nestedPopoverOpener = async ({canvasElement}) => {
   await popoverOpener({ canvasElement });
+  // Prevent flaky chromatic firefox screenshot.
+  await new Promise((resolve) => setTimeout(resolve, 100));
   await popoverOpener({ canvasElement: canvasElement.querySelector('#popover-nested-parent') });
 }
 

--- a/src/components/popover/bl-popover.test.ts
+++ b/src/components/popover/bl-popover.test.ts
@@ -167,4 +167,73 @@ describe("bl-popover", () => {
       expect(popoverEl.visible).to.false;
     });
   });
+
+  it("should hide when another bl-popover triggers show", async () => {
+    const body = await fixture<HTMLBodyElement>(html`
+      <div style="width: 1500px;height: 1500px;">
+        <bl-button id="mybtn"></bl-button>
+        <bl-popover id="mypopover" fit-size placement="bottom" offset="5" target="mybtn">
+          <span>Popover Content</span>
+        </bl-popover>
+        <bl-button id="mybtn-2"></bl-button>
+        <bl-popover id="mypopover2" fit-size placement="bottom" offset="5" target="mybtn2">
+          <span>Popover Content</span>
+        </bl-popover>
+      </div>
+    `);
+
+    const popoverEl = body.querySelector("#mypopover") as typeOfBlPopover;
+    const popoverEl2 = body.querySelector("#mypopover2") as typeOfBlPopover;
+    const btnEl = body.querySelector("bl-button") as typeOfBlButton;
+
+    popoverEl.setAttribute("target", "mybtn");
+    popoverEl2.setAttribute("target", "mybtn-2");
+    btnEl.onclick = () => {
+      popoverEl.show();
+    };
+    await btnEl.click();
+
+    expect(popoverEl.visible).to.true;
+
+    popoverEl2.show();
+
+    setTimeout(() => {
+      expect(popoverEl2.visible).to.true;
+      expect(popoverEl.visible).to.false;
+    });
+  });
+
+  it("should not hide when child bl-popover triggers show", async () => {
+    const body = await fixture<HTMLBodyElement>(html`
+      <div style="width: 1500px;height: 1500px;">
+        <bl-button id="mybtn"></bl-button>
+        <bl-popover id="mypopover" fit-size placement="bottom" offset="5" target="mybtn">
+          <bl-button id="mybtn-2"></bl-button>
+          <bl-popover id="mypopover2" fit-size placement="bottom" offset="5" target="mybtn2">
+            <span>Popover Content</span>
+          </bl-popover>
+        </bl-popover>
+      </div>
+    `);
+
+    const popoverEl = body.querySelector("#mypopover") as typeOfBlPopover;
+    const popoverEl2 = body.querySelector("#mypopover2") as typeOfBlPopover;
+    const btnEl = body.querySelector("bl-button") as typeOfBlButton;
+
+    popoverEl.setAttribute("target", "mybtn");
+    popoverEl2.setAttribute("target", "mybtn-2");
+    btnEl.onclick = () => {
+      popoverEl.show();
+    };
+    await btnEl.click();
+
+    expect(popoverEl.visible).to.true;
+
+    popoverEl2.show();
+
+    setTimeout(() => {
+      expect(popoverEl2.visible).to.true;
+      expect(popoverEl.visible).to.true;
+    });
+  });
 });

--- a/src/components/popover/bl-popover.ts
+++ b/src/components/popover/bl-popover.ts
@@ -219,7 +219,12 @@ export default class BlPopover extends LitElement {
 
   private _handlePopoverShowEvent(event: Event) {
     if (event.target !== this) {
-      this.hide();
+      const { parentElement } = event.target as HTMLElement;
+      const hasPopoverParent = parentElement?.closest("bl-popover") === this;
+
+      if (!hasPopoverParent) {
+        this.hide();
+      }
     }
   }
 

--- a/src/components/popover/bl-popover.ts
+++ b/src/components/popover/bl-popover.ts
@@ -220,9 +220,9 @@ export default class BlPopover extends LitElement {
   private _handlePopoverShowEvent(event: Event) {
     if (event.target !== this) {
       const { parentElement } = event.target as HTMLElement;
-      const hasPopoverParent = parentElement?.closest("bl-popover") === this;
+      const isNestedPopover = this.contains(parentElement);
 
-      if (!hasPopoverParent) {
+      if (!isNestedPopover) {
         this.hide();
       }
     }


### PR DESCRIPTION
This PR will allow users to nest popovers inside of each other. Current implementation doesn't allow the use of `bl-tooltip` inside a popover since `bl-tooltip` also uses popover component. 

Closes #703