### PR TITLE
fix(input): revalidate input on prop changes

### DIFF
--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -285,9 +285,9 @@ export default class BlInput extends FormControlMixin(LitElement) {
       this.setValue(this.value);
 
       await this.validationComplete;
-
-      this.requestUpdate();
     }
+
+    this.requestUpdate();
   }
 
   private inputId = Math.random().toString(36).substring(2);

--- a/src/components/input/bl-input.ts
+++ b/src/components/input/bl-input.ts
@@ -281,13 +281,13 @@ export default class BlInput extends FormControlMixin(LitElement) {
   }
 
   protected async updated(changedProperties: PropertyValues) {
-    if (changedProperties.has("value")) {
+    if (changedProperties.size > 0) {
       this.setValue(this.value);
 
       await this.validationComplete;
-    }
 
-    this.requestUpdate();
+      this.requestUpdate();
+    }
   }
 
   private inputId = Math.random().toString(36).substring(2);


### PR DESCRIPTION
This PR updates input with every attr/prop changes. So validation can be retriggered in case of validation rule changes, without updating the value.

Fixes #704 