### PR TITLE
fix(select): select check additional count event loop

### DIFF
--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -488,7 +488,9 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
       this.value = null;
     }
 
-    this._checkAdditionalItemCount();
+    if (_changedProperties.has("_selectedOptions")) {
+      this._checkAdditionalItemCount();
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes select causing the window to be frozen on choosing x amount of options. This is caused by running `_checkAdditionalItemCount` within updated for each update instead of listening for selected options only.