### PR TITLE
docs(github): create codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Following team members are responsible for the project and will be autoassigned to the PRs
+@Trendyol/baklava


### PR DESCRIPTION
This will auto assign team as reviewer to newly created PRs