### PR TITLE
fix(popover): Fix bl-tooltip trigger issue

### DIFF
--- a/src/components/popover/bl-popover.ts
+++ b/src/components/popover/bl-popover.ts
@@ -222,7 +222,7 @@ export default class BlPopover extends LitElement {
       const { parentElement } = event.target as HTMLElement;
       const isNestedPopover = this.contains(parentElement);
 
-      if (!isNestedPopover) {
+      if (!isNestedPopover && (event.target as HTMLElement).tagName === this.tagName) {
         this.hide();
       }
     }


### PR DESCRIPTION
Nested popover cause this issue, I added tagname control in _handlePopoverShowEvent to prevent unnecessary hide for bl-tooltip

closes #801  