### PR TITLE
fix: Use lowercase script import in using-baklava-in-next.stories.mdx

### DIFF
--- a/docs/using-baklava-in-next.stories.mdx
+++ b/docs/using-baklava-in-next.stories.mdx
@@ -22,7 +22,7 @@ Include Baklava library from CDN to your project's `<head>` section (in `layout.
   href="https://cdn.jsdelivr.net/npm/@trendyol/baklava@3.1.0/dist/themes/default.css"
 />
 
-<Script
+<script
   type="module"
   src="https://cdn.jsdelivr.net/npm/@trendyol/baklava@3.1.0/dist/baklava.js"
 />


### PR DESCRIPTION
Baklava needs to be imported as a module. Next <Script> does not take "type" as a parameter so lowercase <script> should be used.

I am creating a new Next project with Baklava and this solved my issue.