### PR TITLE
fix(tooltip): use mouseenter as event listener

### DIFF
--- a/src/components/tooltip/bl-tooltip.ts
+++ b/src/components/tooltip/bl-tooltip.ts
@@ -61,7 +61,7 @@ export default class BlTooltip extends LitElement {
 
     if (target) {
       target.addEventListener("focus", this.show, { capture: true });
-      target.addEventListener("mouseover", this.show);
+      target.addEventListener("mouseenter", this.show);
       target.addEventListener("blur", this.hide, { capture: true });
       target.addEventListener("mouseleave", this.hide);
     }
@@ -72,7 +72,7 @@ export default class BlTooltip extends LitElement {
 
     if (target) {
       target.removeEventListener("focus", this.show, { capture: true });
-      target.removeEventListener("mouseover", this.show);
+      target.removeEventListener("mouseenter", this.show);
       target.removeEventListener("blur", this.hide, { capture: true });
       target.removeEventListener("mouseleave", this.hide);
     }
@@ -124,7 +124,7 @@ export default class BlTooltip extends LitElement {
       aria-describedby="tooltip"
       @focus=${{ handleEvent: () => this.show(), capture: true }}
       @blur=${{ handleEvent: () => this.hide(), capture: true }}
-      @mouseover=${() => this.show()}
+      @mouseenter=${() => this.show()}
       @mouseleave=${() => this.hide()}
     >
     </slot>`;


### PR DESCRIPTION
closes #908 

I noticed there is a problem when we use `mouseover` as event listener in bl-tooltip component. mouseever triggered for every children inside tooltip trigger slot. It should be triggered only once when mouse entered the tooltip trigger slot element instead of its children. If we use `mouseenter` as event listener it seems problem solved.

I put the video about this case also:

https://github.com/user-attachments/assets/a7b4ea3b-8c5a-47e9-9dbc-69a62da5d7d1

