### PR TITLE
fix(bl-calendar): Add RTL support for arrow icons to prevent visual s…

### DIFF
--- a/src/components/calendar/bl-calendar.css
+++ b/src/components/calendar/bl-calendar.css
@@ -24,6 +24,7 @@
 
 .arrow {
   flex: 1;
+  direction: ltr;
 }
 
 .header-text {


### PR DESCRIPTION
Issue
When the user selects RTL mode, the calendar icons are swapped incorrectly.

Fix
Explicitly set direction: ltr to ensure icons remain in the correct order.
Resolved incorrect icon placement while maintaining RTL layout.