### PR TITLE
feat (calendar): add hover tooltip functionality

### DIFF
--- a/src/components/calendar/bl-calendar.css
+++ b/src/components/calendar/bl-calendar.css
@@ -147,4 +147,5 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--bl-size-xs);
 }

--- a/src/components/calendar/bl-calendar.css
+++ b/src/components/calendar/bl-calendar.css
@@ -147,5 +147,5 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--bl-size-xs);
+  padding: var(--bl-size-m);
 }

--- a/src/components/calendar/bl-calendar.css
+++ b/src/components/calendar/bl-calendar.css
@@ -147,5 +147,5 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--bl-size-m);
+  padding: var(--bl-calendar-tooltip-padding, 0);
 }

--- a/src/components/calendar/bl-calendar.css
+++ b/src/components/calendar/bl-calendar.css
@@ -147,5 +147,4 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--bl-size-m);
 }

--- a/src/components/calendar/bl-calendar.css
+++ b/src/components/calendar/bl-calendar.css
@@ -142,3 +142,10 @@
 .calendar-text {
   font: var(--bl-font-title-3-regular);
 }
+
+.tooltip-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--bl-size-m);
+}

--- a/src/components/calendar/bl-calendar.stories.mdx
+++ b/src/components/calendar/bl-calendar.stories.mdx
@@ -24,7 +24,8 @@ export const CalendarTemplate = (args) => html`
     start-of-week=${ifDefined(args.startOfWeek)}
     locale=${ifDefined(args.locale)}
     value=${ifDefined(args.value)}
-    disabled-dates=${ifDefined(args.disabledDates)}>${unsafeHTML(args.content)}
+    disabled-dates=${ifDefined(args.disabledDates)}
+    .tooltipData=${ifDefined(args.tooltipData)}>${unsafeHTML(args.content)}
   </bl-calendar>`
 
 
@@ -46,7 +47,7 @@ Calendar component is an **internal** component for using inside Datepicker comp
 * Calendar has **min-date** and **max-date** attributes.By entering these values,you can disable all dates before min-date property or will disable all dates after max-date property.
 * Another attribute **disabled-dates** is also restrict the dates that can be selected on the calendar.
 * Attribute **start-of-date** defines the days of the week, corresponding to 0 Sundays and 6 Saturdays. By entering this, you can choose from which day the calendar will create the calendar view.
-
+* Attribute **tooltip-data** is used to set tooltip for specific dates. It is an array of objects. Each object has `dates` and `tooltip` properties. `dates` is an array of dates in string format and `tooltip` is the tooltip text.
 
 ## Calendar Types
 
@@ -106,6 +107,31 @@ You can set dates which you want to disable from calendar.
     {Template.bind({})}
   </Story>
 </Canvas>
+
+
+### Tooltip on Dates
+
+You can set tooltip for specific dates.
+You can pass tooltip data as an array of objects. Each object has `dates` and `tooltip` properties. `dates` is an array of dates in string format and `tooltip` is the tooltip text.
+For example:
+
+```json
+[
+  { "dates": ["Apr 1 2025", "Apr 2 2025"], "tooltip": "Tooltip1" },
+  { "dates": ["Apr 14 2025", "Apr 15 2025", "Apr 16 2025"], "tooltip": "Tooltip2 }
+]
+```
+
+<Canvas>
+  <Story name="Tooltip" args={{
+    type: 'single',
+    tooltipData: [{ dates: ['Apr 1 2025', 'Apr 12 2025', 'Apr 13 2025'], tooltip: 'Tooltip for dates' }],
+    disabledDates: ['Apr 12 2025', 'Apr 13 2025', 'Apr 14 2025']
+  }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
 
 ## RTL Support
 

--- a/src/components/calendar/bl-calendar.stories.mdx
+++ b/src/components/calendar/bl-calendar.stories.mdx
@@ -126,7 +126,8 @@ For example:
   <Story name="Tooltip" args={{
     type: 'single',
     tooltipData: [{ dates: ['Apr 1 2025', 'Apr 12 2025', 'Apr 13 2025'], tooltip: 'Tooltip for dates' }],
-    disabledDates: ['Apr 12 2025', 'Apr 13 2025', 'Apr 14 2025']
+    disabledDates: ['Apr 12 2025', 'Apr 13 2025', 'Apr 14 2025'],
+    value: "Apr 1 2025"
   }}>
     {Template.bind({})}
   </Story>

--- a/src/components/calendar/bl-calendar.test.ts
+++ b/src/components/calendar/bl-calendar.test.ts
@@ -1,8 +1,8 @@
-import { expect, fixture, html, aTimeout } from "@open-wc/testing";
+import { expect, fixture, html } from "@open-wc/testing";
 import "./bl-calendar";
 import { BlButton, BlCalendar } from "../../baklava";
 import { CALENDAR_TYPES, CALENDAR_VIEWS, FIRST_MONTH_INDEX, LAST_MONTH_INDEX } from "./bl-calendar.constant";
-import sinon from "sinon";
+import sinon, { SinonFakeTimers } from "sinon";
 
 describe("bl-calendar", () => {
   let element: BlCalendar;
@@ -604,6 +604,7 @@ describe("bl-calendar", () => {
   });
 
   describe("Tooltip Functionality", () => {
+    let clock: SinonFakeTimers;
     const tooltipData = [
       {
         dates: ["Apr 12 2025"],
@@ -616,16 +617,22 @@ describe("bl-calendar", () => {
     ];
 
     beforeEach(async () => {
+      clock = sinon.useFakeTimers(new Date("2025-04-12").getTime());
       element._calendarMonth = 4;
       element._calendarYear = 2025;
       await element.updateComplete;
+    });
+
+    afterEach(() => {
+      clock.restore();
     });
 
     it("should not render any tooltips if tooltipData is not provided or empty", async () => {
       element.tooltipData = [];
       element.requestUpdate();
       await element.updateComplete;
-      await aTimeout(0);
+      // because we are using fake timers, we need to tick the clock manually
+      clock.tick(0);
       const tooltips = element.shadowRoot?.querySelectorAll("bl-tooltip");
 
       expect(tooltips?.length).to.equal(0);
@@ -637,7 +644,8 @@ describe("bl-calendar", () => {
 
       element.requestUpdate();
       await element.updateComplete;
-      await aTimeout(100);
+      // because we are using fake timers, we need to tick the clock manually
+      clock.tick(100);
 
       const actualTooltipText12 = getTooltipTextByDayButtonText(element, "12");
       const expectedTooltipText12 = tooltipData[0].tooltip;

--- a/src/components/calendar/bl-calendar.test.ts
+++ b/src/components/calendar/bl-calendar.test.ts
@@ -13,6 +13,7 @@ describe("bl-calendar", () => {
     element = await fixture<BlCalendar>(html`
       <bl-calendar locale="en"></bl-calendar>`);
     consoleWarnSpy = sinon.spy(console, "warn");
+
   });
 
   afterEach(() => {
@@ -603,8 +604,6 @@ describe("bl-calendar", () => {
   });
 
   describe("Tooltip Functionality", () => {
-    let clock: sinon.SinonFakeTimers;
-
     const tooltipData = [
       {
         dates: ["Apr 12 2025"],
@@ -617,15 +616,9 @@ describe("bl-calendar", () => {
     ];
 
     beforeEach(async () => {
-      clock = sinon.useFakeTimers(new Date(2025, 3, 10).getTime());
-
-      element = await fixture<BlCalendar>(html`
-        <bl-calendar locale="en"></bl-calendar>`);
+      element._calendarMonth = 4;
+      element._calendarYear = 2025;
       await element.updateComplete;
-    });
-
-    afterEach(() => {
-      clock.restore();
     });
 
     it("should not render any tooltips if tooltipData is not provided or empty", async () => {
@@ -639,32 +632,25 @@ describe("bl-calendar", () => {
     });
 
     it("should render tooltips for dates if tooltipData is provided", async () => {
-      element.tooltipData = tooltipData;
+      element = await fixture<BlCalendar>(html`
+        <bl-calendar .tooltipData=${tooltipData}></bl-calendar>`);
+
       element.requestUpdate();
       await element.updateComplete;
       await aTimeout(100);
-      await aTimeout(100);
-
-      expect(element._calendarMonth).to.equal(3);
-      expect(element._calendarYear).to.equal(2025);
 
       const actualTooltipText12 = getTooltipTextByDayButtonText(element, "12");
       const expectedTooltipText12 = tooltipData[0].tooltip;
 
       expect(actualTooltipText12, "Tooltip text for day 12 should be found").to.equal(expectedTooltipText12);
-      const actualTooltipText14 = getTooltipTextByDayButtonText(element, "14");
-      const expectedTooltipText14 = tooltipData[1].tooltip;
-
-      expect(actualTooltipText14, "Tooltip text for day 14 should be found").to.equal(expectedTooltipText14);
     });
 
-    const getTooltipTextByDayButtonText = (calendarElement: BlCalendar, dayText: string) => {
+    const getTooltipTextByDayButtonText = (calendarElement: BlCalendar, dayText: string): string | null | undefined => {
       let targetButton: Element | null = null;
-      const dayWrapperDivs = calendarElement.shadowRoot?.querySelectorAll(".day-wrapper");
+      const dayWrapperDivs  = calendarElement.shadowRoot?.querySelectorAll(".day-wrapper");
 
       dayWrapperDivs?.forEach(dayWrapperDiv => {
-        const tooltip = dayWrapperDiv.querySelector("bl-tooltip");
-        const button = tooltip?.querySelector("bl-button") || dayWrapperDiv.querySelector("bl-button");
+        const button = dayWrapperDiv?.querySelector("bl-button");
 
         if (button?.textContent?.trim() === dayText) {
           targetButton = button;
@@ -673,8 +659,7 @@ describe("bl-calendar", () => {
 
       if (!targetButton) return undefined;
 
-      const tooltip = (targetButton as Element).closest("bl-tooltip");
-      const tooltipContentDiv = tooltip?.querySelector("[slot='content']");
+      const tooltipContentDiv = (targetButton as BlButton).nextElementSibling;
 
       return tooltipContentDiv?.textContent?.trim();
     };

--- a/src/components/calendar/bl-calendar.ts
+++ b/src/components/calendar/bl-calendar.ts
@@ -42,10 +42,19 @@ export default class BlCalendar extends DatepickerCalendarMixin {
   _dates: Date[] = [];
 
   /**
+   * Map of tooltip data for specific dates, key is the date in milliseconds and value is the tooltip text
+   */
+  @state()
+  _tooltipDataMap: Map<number, string> = new Map();
+
+  /**
    * Tooltip data for specific dates
    */
   @property({ type: Array })
-  tooltipData: TooltipDateItem[] = [];
+  set tooltipData(tooltipData: TooltipDateItem[]) {
+    // we are creating a map of tooltip data for faster lookup
+    this._tooltipDataMap = this.createTooltipDataMap(tooltipData);
+  }
 
   /**
    * Fires when date selection changes
@@ -366,6 +375,16 @@ export default class BlCalendar extends DatepickerCalendarMixin {
     return calendar;
   }
 
+  createTooltipDataMap(tooltipData: TooltipDateItem[]) {
+    const tooltipDataMap = new Map<number, string>();
+
+    tooltipData?.forEach(item => {
+      item.dates?.forEach(dateStr => tooltipDataMap.set(new Date(dateStr).getTime(), item.tooltip));
+    });
+
+    return tooltipDataMap;
+  }
+
   updated(changedProperties: PropertyValues) {
     if (changedProperties.has("value")) {
       const dates = formatToDateArray(this._value);
@@ -548,24 +567,6 @@ export default class BlCalendar extends DatepickerCalendarMixin {
    * Find tooltip content for a specific date
    */
   findTooltipForDate(date: Date) {
-    if (!this.tooltipData || !this.tooltipData.length) {
-      return null;
-    }
-
-    const formattedDate = date.toDateString();
-
-    for (const item of this.tooltipData) {
-      const isDateInTooltip = item.dates.some(dateStr => {
-        const itemDate = new Date(dateStr).toDateString();
-
-        return itemDate === formattedDate;
-      });
-
-      if (isDateInTooltip) {
-        return item.tooltip;
-      }
-    }
-
-    return null;
+    return this._tooltipDataMap.get(date.getTime());
   }
 }

--- a/src/components/calendar/bl-calendar.ts
+++ b/src/components/calendar/bl-calendar.ts
@@ -50,7 +50,7 @@ export default class BlCalendar extends DatepickerCalendarMixin {
   /**
    * Tooltip data for specific dates
    */
-  @property({ type: Array })
+  @property({ type: Array, attribute: "tooltip-data", reflect: true })
   set tooltipData(tooltipData: TooltipDateItem[]) {
     // we are creating a map of tooltip data for faster lookup
     this._tooltipDataMap = this.createTooltipDataMap(tooltipData);
@@ -379,7 +379,9 @@ export default class BlCalendar extends DatepickerCalendarMixin {
     const tooltipDataMap = new Map<number, string>();
 
     tooltipData?.forEach(item => {
-      item.dates?.forEach(dateStr => tooltipDataMap.set(new Date(dateStr).getTime(), item.tooltip));
+      item.dates?.forEach(dateStr =>
+        tooltipDataMap.set(new Date(dateStr)?.getTime(), item.tooltip)
+      );
     });
 
     return tooltipDataMap;

--- a/src/components/datepicker/bl-datepicker.css
+++ b/src/components/datepicker/bl-datepicker.css
@@ -45,6 +45,11 @@
   margin-right: var(--bl-size-3xs);
 }
 
+bl-popover {
+  --bl-popover-padding: 0;
+  --bl-popover-background-color: transparent;
+}
+
 .date-tooltip {
   position: absolute;
   z-index: 10;

--- a/src/components/datepicker/bl-datepicker.css
+++ b/src/components/datepicker/bl-datepicker.css
@@ -49,3 +49,9 @@ bl-popover {
   --bl-popover-padding: 0;
   --bl-popover-background-color: transparent;
 }
+
+.date-tooltip {
+  position: absolute;
+  z-index: 10;
+  pointer-events: none;
+}

--- a/src/components/datepicker/bl-datepicker.css
+++ b/src/components/datepicker/bl-datepicker.css
@@ -45,11 +45,6 @@
   margin-right: var(--bl-size-3xs);
 }
 
-bl-popover {
-  --bl-popover-padding: 0;
-  --bl-popover-background-color: transparent;
-}
-
 .date-tooltip {
   position: absolute;
   z-index: 10;

--- a/src/components/datepicker/bl-datepicker.css
+++ b/src/components/datepicker/bl-datepicker.css
@@ -1,6 +1,7 @@
 :host {
   width: 314px;
   display: block;
+  --bl-calendar-tooltip-padding: 16px !important;
 }
 
 .datepicker-content {

--- a/src/components/datepicker/bl-datepicker.stories.mdx
+++ b/src/components/datepicker/bl-datepicker.stories.mdx
@@ -127,10 +127,12 @@ You can pass tooltip data as an array of objects. Each object has `dates` and `t
 For example:
 
 ```json
-[
-  { "dates": ["Apr 1 2025", "Apr 2 2025"], "tooltip": "Tooltip1" },
-  { "dates": ["Apr 14 2025", "Apr 15 2025", "Apr 16 2025"], "tooltip": "Tooltip2 }
-]
+{
+  "tooltipData": [
+    { "dates": ["Apr 1 2025", "Apr 2 2025"], "tooltip": "Tooltip1" },
+    { "dates": ["Apr 14 2025", "Apr 15 2025", "Apr 16 2025"], "tooltip": "Tooltip2" }
+  ]
+}
 ```
 
 <Canvas>
@@ -138,7 +140,33 @@ For example:
     type: 'multiple',
     label: 'Tooltip Data',
     placeholder: 'Set tooltip data',
-    tooltipData: [{ dates: ['Apr 1 2025', 'Apr 2 2025'], tooltip: 'Tooltip for dates' }]
+    tooltipData: [
+      { dates: ['Apr 1 2025', 'Apr 2 2025'], tooltip: 'Tooltip1' },
+      { dates: ['Apr 14 2025', 'Apr 15 2025', 'Apr 16 2025'], tooltip: 'Tooltip2' }
+    ]
+  }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Tooltip on Disabled Dates
+
+You can also set tooltip for specific dates which are disabled. Below is an example of how to set a tooltip for disabled dates.
+
+```json
+{
+  "disabledDates": "Apr 15 2025, Apr 16 2025",
+  "tooltipData": [{ "dates": ["Apr 15 2025", "Apr 16 2025"], "tooltip": "Tooltip1 on disabled date" }]
+}
+```
+
+<Canvas>
+  <Story name="Tooltip on Disabled Dates" args={{
+    type: 'multiple',
+    label: 'Tooltip on Disabled Dates',
+    placeholder: 'Set tooltip data',
+    disabledDates: "Apr 15 2025, Apr 16 2025",
+    tooltipData: [{ dates: ['Apr 15 2025', 'Apr 16 2025'], tooltip: 'Tooltip1 on disabled date' }]
   }}>
     {Template.bind({})}
   </Story>

--- a/src/components/datepicker/bl-datepicker.stories.mdx
+++ b/src/components/datepicker/bl-datepicker.stories.mdx
@@ -143,7 +143,8 @@ For example:
     tooltipData: [
       { dates: ['Apr 1 2025', 'Apr 2 2025'], tooltip: 'Tooltip1' },
       { dates: ['Apr 14 2025', 'Apr 15 2025', 'Apr 16 2025'], tooltip: 'Tooltip2' }
-    ]
+    ],
+    value: "Apr 1 2025"
   }}>
     {Template.bind({})}
   </Story>
@@ -166,7 +167,8 @@ You can also set tooltip for specific dates which are disabled. Below is an exam
     label: 'Tooltip on Disabled Dates',
     placeholder: 'Set tooltip data',
     disabledDates: "Apr 15 2025, Apr 16 2025",
-    tooltipData: [{ dates: ['Apr 15 2025', 'Apr 16 2025'], tooltip: 'Tooltip1 on disabled date' }]
+    tooltipData: [{ dates: ['Apr 15 2025', 'Apr 16 2025'], tooltip: 'Tooltip1 on disabled date' }],
+    value: "Apr 14 2025"
   }}>
     {Template.bind({})}
   </Story>

--- a/src/components/datepicker/bl-datepicker.stories.mdx
+++ b/src/components/datepicker/bl-datepicker.stories.mdx
@@ -27,7 +27,8 @@ export const DatepickerTemplate = (args) => html`
     locale=${ifDefined(args.locale)}
     value=${ifDefined(args.value)}
     style=${ifDefined(args.style)}
-    disabled-dates=${ifDefined(args.disabledDates)}>${unsafeHTML(args.content)}
+    disabled-dates=${ifDefined(args.disabledDates)}
+    .tooltipData=${ifDefined(args.tooltipData)}>${unsafeHTML(args.content)}
   </bl-datepicker>`
 
 
@@ -49,7 +50,7 @@ Datepicker renders the calendar component within itself and provides the functio
 * Datepicker has **min-date** and **max-date** attributes.By entering these values,you can disable all dates before min-date property or will disable all dates after max-date property.
 * Another attribute **disabled-dates** is also restrict the dates that can be selected on the datepicker.
 * Attribute **start-of-date** defines the days of the week, corresponding to 0 Sundays and 6 Saturdays. By entering this, you can choose from which day the datepicker will create the datepicker view.
-
+* Attribute **tooltip-data** is used to set tooltip for specific dates. It is an array of objects. Each object has `dates` and `tooltip` properties. `dates` is an array of dates in string format and `tooltip` is the tooltip text.
 
 ## Datepicker Types
 
@@ -114,6 +115,30 @@ You can set dates which you want to disable from Datepicker.
     label: 'Disabled Dates',
     placeholder: 'Set disabled dates',
     disabledDates: new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() + 2)
+  }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Tooltip on Dates
+
+You can set tooltip for specific dates.
+You can pass tooltip data as an array of objects. Each object has `dates` and `tooltip` properties. `dates` is an array of dates in string format and `tooltip` is the tooltip text.
+For example:
+
+```json
+[
+  { "dates": ["Apr 1 2025", "Apr 2 2025"], "tooltip": "Tooltip1" },
+  { "dates": ["Apr 14 2025", "Apr 15 2025", "Apr 16 2025"], "tooltip": "Tooltip2 }
+]
+```
+
+<Canvas>
+  <Story name="Tooltip Data" args={{
+    type: 'multiple',
+    label: 'Tooltip Data',
+    placeholder: 'Set tooltip data',
+    tooltipData: [{ dates: ['Apr 1 2025', 'Apr 2 2025'], tooltip: 'Tooltip for dates' }]
   }}>
     {Template.bind({})}
   </Story>

--- a/src/components/datepicker/bl-datepicker.test.ts
+++ b/src/components/datepicker/bl-datepicker.test.ts
@@ -317,4 +317,21 @@ describe("BlDatepicker", () => {
     expect(focusSpy.called).to.be.true;
   });
 
+  it("should pass tooltipData to the calendar component", async () => {
+    const tooltipData = [
+      { dates: ["Jan 01 2024"], tooltip: "New Year" },
+      { dates: ["Dec 25 2024"], tooltip: "Christmas" },
+    ];
+
+    element.tooltipData = tooltipData;
+    await element.updateComplete;
+
+    // Ensure the popover is open to render the calendar
+    element.openPopover();
+    await element.updateComplete;
+
+    expect(element._calendarEl).to.exist;
+    expect(element._calendarEl.tooltipData).to.deep.equal(tooltipData);
+  });
+
 });

--- a/src/components/datepicker/bl-datepicker.test.ts
+++ b/src/components/datepicker/bl-datepicker.test.ts
@@ -316,22 +316,4 @@ describe("BlDatepicker", () => {
 
     expect(focusSpy.called).to.be.true;
   });
-
-  it("should pass tooltipData to the calendar component", async () => {
-    const tooltipData = [
-      { dates: ["Jan 01 2024"], tooltip: "New Year" },
-      { dates: ["Dec 25 2024"], tooltip: "Christmas" },
-    ];
-
-    element.tooltipData = tooltipData;
-    await element.updateComplete;
-
-    // Ensure the popover is open to render the calendar
-    element.openPopover();
-    await element.updateComplete;
-
-    expect(element._calendarEl).to.exist;
-    expect(element._calendarEl.tooltipData).to.deep.equal(tooltipData);
-  });
-
 });

--- a/src/components/datepicker/bl-datepicker.ts
+++ b/src/components/datepicker/bl-datepicker.ts
@@ -15,7 +15,7 @@ import style from "./bl-datepicker.css";
  */
 export interface TooltipDateItem {
   dates: string[];
-  tooltip: string | TemplateResult;
+  tooltip: string;
 }
 
 /**

--- a/src/components/datepicker/bl-datepicker.ts
+++ b/src/components/datepicker/bl-datepicker.ts
@@ -77,7 +77,7 @@ export default class BlDatepicker extends DatepickerCalendarMixin {
    *   }
    * ]
    */
-  @property({ type: Array })
+  @property({ type: Array, attribute: "tooltip-data", reflect: true })
   tooltipData: TooltipDateItem[] = [];
 
   @state()

--- a/src/components/datepicker/bl-datepicker.ts
+++ b/src/components/datepicker/bl-datepicker.ts
@@ -11,6 +11,14 @@ import "../tooltip/bl-tooltip";
 import style from "./bl-datepicker.css";
 
 /**
+ * Date tooltip data type
+ */
+export interface TooltipDateItem {
+  dates: string[];
+  tooltip: string | TemplateResult;
+}
+
+/**
  * @tag bl-datepicker
  * @summary Baklava DatePicker component
  *
@@ -54,6 +62,23 @@ export default class BlDatepicker extends DatepickerCalendarMixin {
    */
   @property({ type: String, attribute: "help-text", reflect: true })
   helpText: string;
+
+  /**
+   * Tooltip data for specific dates
+   * Example:
+   * [
+   *   {
+   *     dates: ["Apr 12 2025"],
+   *     tooltip: "Holiday"
+   *   },
+   *   {
+   *     dates: ["Apr 13 2025", "Apr 14 2025"],
+   *     tooltip: "Weekend"
+   *   }
+   * ]
+   */
+  @property({ type: Array })
+  tooltipData: TooltipDateItem[] = [];
 
   @state()
   _inputValue = "";
@@ -214,6 +239,7 @@ export default class BlDatepicker extends DatepickerCalendarMixin {
           .disabledDates=${this.disabledDates}
           .value=${this.value}
           .locale=${this.locale}
+          .tooltipData=${this.tooltipData}
           @bl-calendar-change="${this.onCalendarChange}"
         ></bl-calendar>
       </bl-popover>


### PR DESCRIPTION
In this MR we added tooltip functionality to calendar component(also datepicker), user can give tooltip data with date and tooltip text info and calendar will show `bl-tooltip` component on day hover.

![Screenshot 2025-04-21 at 13 16 20](https://github.com/user-attachments/assets/ed6a9fd3-d9dd-4474-9aa6-75066d69dde1)

Todo List

- [x] Implement tooltip functionality
- [x] Add example of the new feature
- [x] Update tests
- [x] Update necessary Storybook stories


There is an example for the usage of new tooltip functionality

```html
<!DOCTYPE html>
<html lang="tr">
<head>
  <meta charset="UTF-8" />
  <meta content="width=device-width, initial-scale=1.0" name="viewport" />
  <title>Baklava Playground</title>
  <link href="./dist/themes/default.css" rel="stylesheet" />
  <script src="./dist/localization.js" type="module"></script>
  <script src="./dist/baklava.js" type="module"></script>
</head>
<body>
<h1>Baklava Playground</h1>


<p>Datepicker Example</p>

<bl-datepicker
  label="Disabled Dates"
  placeholder="Set disabled dates"
  type="multiple"
  disabled-dates="Apr 12 2025, Apr 13 2025, Apr 14 2025, Apr 1 2025"
  tooltip-data='[
    {
      "dates": ["Apr 12 2025"],
      "tooltip": "Holiday - Not Available"
    },
    {
      "dates": ["Apr 13 2025", "Apr 14 2025", "Apr 15 2025"],
      "tooltip": "Weekend - Limited Availability"
    }
  ]'
  id="datepicker-example">
</bl-datepicker>


<p>Calendar Example</p>

<bl-calendar
  label="Disabled Dates"
  placeholder="Set disabled dates"
  type="multiple"
  disabled-dates="Apr 12 2025, Apr 13 2025, Apr 14 2025, Apr 1 2025"
  tooltip-data='[
    {
      "dates": ["Apr 12 2025"],
      "tooltip": "Holiday - Not Available"
    },
    {
      "dates": ["Apr 13 2025", "Apr 14 2025", "Apr 15 2025"],
      "tooltip": "Weekend - Limited Availability"
    }
  ]'
  id="calendar-example">
</bl-calendar>

<script>
  window.addEventListener('DOMContentLoaded', () => {
    const tooltipData = [
      {
        dates: ["Apr 12 2025"],
        tooltip: "Holiday - Not Available"
      },
      {
        dates: ["Apr 13 2025", "Apr 14 2025", "Apr 15 2025"],
        tooltip: "Weekend - Limited Availability"
      }
    ];

    // Set the tooltip data on the datepicker
    const datepicker = document.getElementById('datepicker-example');
    datepicker.tooltipData = tooltipData;
  });
</script>

</body>
</html>

``` 
